### PR TITLE
Simplify radialHit() logic.

### DIFF
--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -5,6 +5,8 @@
 #include <limits>
 
 namespace svr {
+    // An array of step values used to avoid branch prediction in radialHit().
+    constexpr std::array<int, 3> step{0, -1, 1};
 
     // Epsilons used for floating point comparisons in Knuth's algorithm.
     const double ABS_EPSILON = 1e-12;
@@ -191,17 +193,16 @@ namespace svr {
                     .previous_transition_flag=false,
                     .within_bounds=false};
         }
-        const std::array<int, 3> step{0, -1, 1};
         const double intersection_time = data.times_gt_t[0];
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
         const bool is_not_tangential_hit = !(data.times_gt_t.size() >= 2 &&
-                                    isKnEqual(data.intersection_times[0], data.intersection_times[1]));
+                                             isKnEqual(data.intersection_times[0], data.intersection_times[1]));
         return {.tMaxR=intersection_time,
                 .within_bounds=KnLessThan(t, intersection_time) &&
                                KnLessThan(intersection_time, t_end),
                 .previous_transition_flag=is_radial_transition,
-                .tStepR=step[(1 * is_not_tangential_hit) +
+                .tStepR=step[1 * is_not_tangential_hit +
                              (is_not_tangential_hit && !is_radial_transition && KnLessThan(r_new, current_radius))]
                };
     }

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -191,16 +191,17 @@ namespace svr {
                     .previous_transition_flag=false,
                     .within_bounds=false};
         }
+        const std::array<int, 2> step{-1, 1};
         const double intersection_time = data.times_gt_t[0];
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
+        const bool is_tangential_hit = data.times_gt_t.size() >= 2 &&
+                                    isKnEqual(data.intersection_times[0], data.intersection_times[1]);
         return {.tMaxR=intersection_time,
                 .within_bounds=KnLessThan(t, intersection_time) &&
                                KnLessThan(intersection_time, t_end),
                 .previous_transition_flag=is_radial_transition,
-                .tStepR=(data.times_gt_t.size() >= 2 &&
-                         isKnEqual(data.intersection_times[0], data.intersection_times[1])) ? 0 :
-                         (!is_radial_transition && KnLessThan(r_new, current_radius))       ? 1 : -1
+                .tStepR=is_tangential_hit ? 0 : step[(!is_radial_transition && KnLessThan(r_new, current_radius))]
                };
     }
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -191,17 +191,18 @@ namespace svr {
                     .previous_transition_flag=false,
                     .within_bounds=false};
         }
-        const std::array<int, 2> step{-1, 1};
+        const std::array<int, 3> step{0, -1, 1};
         const double intersection_time = data.times_gt_t[0];
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
-        const bool is_tangential_hit = data.times_gt_t.size() >= 2 &&
-                                    isKnEqual(data.intersection_times[0], data.intersection_times[1]);
+        const bool is_not_tangential_hit = !(data.times_gt_t.size() >= 2 &&
+                                    isKnEqual(data.intersection_times[0], data.intersection_times[1]));
         return {.tMaxR=intersection_time,
                 .within_bounds=KnLessThan(t, intersection_time) &&
                                KnLessThan(intersection_time, t_end),
                 .previous_transition_flag=is_radial_transition,
-                .tStepR=is_tangential_hit ? 0 : step[(!is_radial_transition && KnLessThan(r_new, current_radius))]
+                .tStepR=step[(1 * is_not_tangential_hit) +
+                             (is_not_tangential_hit && !is_radial_transition && KnLessThan(r_new, current_radius))]
                };
     }
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -9,8 +9,8 @@ namespace svr {
     constexpr std::array<int, 3> step{0, -1, 1};
 
     // Epsilons used for floating point comparisons in Knuth's algorithm.
-    const double ABS_EPSILON = 1e-12;
-    const double REL_EPSILON = 1e-8;
+    constexpr double ABS_EPSILON = 1e-12;
+    constexpr double REL_EPSILON = 1e-8;
 
     // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
     enum VoxelIntersectionType {

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -103,70 +103,70 @@ struct SphericalVoxelGrid {
 					 });
   }
 
-  inline std::size_t
+  constexpr inline std::size_t
   numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
 
-  inline std::size_t
+  constexpr inline std::size_t
   numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
 
-  inline std::size_t
+  constexpr inline std::size_t
   numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
 
-  inline double
+  constexpr inline double
   invNumRadialVoxels() const noexcept { return this->inv_num_radial_voxels_; }
 
-  inline double
+  constexpr inline double
   invNumAngularVoxels() const noexcept { return this->inv_num_angular_voxels_; }
 
-  inline double
+  constexpr inline double
   invNumAzimuthalVoxels() const noexcept { return this->inv_num_azimuthal_voxels_; }
 
-  inline BoundVec3
+  constexpr inline BoundVec3
   minBound() const noexcept { return this->min_bound_; }
 
-  inline BoundVec3
+  constexpr inline BoundVec3
   maxBound() const noexcept { return this->max_bound_; }
 
-  inline double
+  constexpr inline double
   sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
-  inline BoundVec3
+  constexpr inline BoundVec3
   sphereCenter() const noexcept { return this->sphere_center_; }
 
-  inline double
+  constexpr inline double
   deltaRadius() const noexcept { return this->delta_radius_; }
 
-  inline double
+  constexpr inline double
   deltaTheta() const noexcept { return this->delta_theta_; }
 
-  inline double
+  constexpr inline double
   deltaPhi() const noexcept { return this->delta_phi_; }
 
-  inline double
+  constexpr inline double
   invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
 
-  inline double
+  constexpr inline double
   invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
 
-  inline double
+  constexpr inline double
   invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
 
-  inline const LineSegment &
+  constexpr inline const LineSegment &
   pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
-  inline const std::vector<LineSegment> &
+  constexpr inline const std::vector<LineSegment> &
   pMaxAngular() const noexcept { return this->P_max_angular_; }
 
-  inline const LineSegment &
+  constexpr inline const LineSegment &
   pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
-  inline const std::vector<LineSegment> &
+  constexpr inline const std::vector<LineSegment> &
   pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
 
-  inline const std::vector<TrigonometricValues> &
+  constexpr inline const std::vector<TrigonometricValues> &
   angularTrigValues() const noexcept { return angular_trig_values_; }
 
-  inline const std::vector<TrigonometricValues> &
+  constexpr inline const std::vector<TrigonometricValues> &
   azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
 
  private:

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -13,13 +13,13 @@
 //      [z]
 struct Vec3 {
 public:
-    inline Vec3(const double x, const double y, const double z) : x_(x), y_(y), z_(z) {}
+    constexpr inline Vec3(const double x, const double y, const double z) : x_(x), y_(y), z_(z) {}
 
-    inline double x() const noexcept { return this->x_; }
+    constexpr inline double x() const noexcept { return this->x_; }
 
-    inline double y() const noexcept { return this->y_; }
+    constexpr inline double y() const noexcept { return this->y_; }
 
-    inline double z() const noexcept { return this->z_; }
+    constexpr inline double z() const noexcept { return this->z_; }
 
     inline double &x() noexcept { return this->x_; }
 
@@ -31,17 +31,17 @@ public:
         return std::sqrt(this->x_ * this->x_ + this->y_ * this->y_ + this->z_ * this->z_);
     }
 
-    inline double squared_length() const noexcept {
+    constexpr inline double squared_length() const noexcept {
         return x_ * x_ + y_ * y_ + z_ * z_;
     }
 
-  inline double operator[](const std::size_t index) const noexcept {
-      switch(index) {
+    inline double operator[](const std::size_t index) const noexcept {
+        switch(index) {
           case 0: return this->x_;
           case 1: return this->y_;
           case 2: return this->z_;
-      }
-      return std::numeric_limits<double>::quiet_NaN();
+        }
+        return std::numeric_limits<double>::quiet_NaN();
   }
 
 private:
@@ -60,11 +60,11 @@ private:
 //                  Langr, J. "Modern C++ Programming with Test-Driven Development: Code Better, Sleep Better" [5.10]
 struct FreeVec3 : Vec3 {
 
-    inline explicit FreeVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
+    constexpr inline explicit FreeVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
 
-    inline explicit FreeVec3(double x, double y, double z) : Vec3(x, y, z) {}
+    constexpr inline explicit FreeVec3(double x, double y, double z) : Vec3(x, y, z) {}
 
-    inline double dot(const Vec3 &other) const noexcept {
+    constexpr inline double dot(const Vec3 &other) const noexcept {
         return this->x() * other.x() + this->y() * other.y() + this->z() * other.z();
     }
 
@@ -122,11 +122,11 @@ inline FreeVec3 operator/(FreeVec3 v, const double scalar) noexcept {
 // A 3-dimensional bounded vector has a fixed start and end point. It represents a fixed point
 // in space, relative to some frame of reference.
 struct BoundVec3 : Vec3 {
-    inline explicit BoundVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
+    constexpr inline explicit BoundVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
 
-    inline explicit BoundVec3(double x, double y, double z) : Vec3(x, y, z) {}
+    constexpr inline explicit BoundVec3(double x, double y, double z) : Vec3(x, y, z) {}
 
-    inline double dot(const Vec3 &other) const noexcept {
+    constexpr inline double dot(const Vec3 &other) const noexcept {
         return this->x() * other.x() + this->y() * other.y() + this->z() * other.z();
     }
 
@@ -172,7 +172,7 @@ struct UnitVec3 {
 
     inline double z() const noexcept { return this->to_free().z(); }
 
-    inline const FreeVec3 &to_free() const noexcept { return inner_; }
+    constexpr inline const FreeVec3 &to_free() const noexcept { return inner_; }
 
     inline double operator[](const std::size_t index) const noexcept {
         switch(index) {


### PR DESCRIPTION
First, we can exit early if there is no intersection.

Then, since a tangential hit and a normal radial intersection are only different when calculating tStepR, we only need a boolean for that case.

To avoid branch prediction slowdown, we can simply create an array {0, -1, 1}. Since ```true == 1``` and ```false == 0```, we can use some quick algebra to determine the right step value.

Also uses constexpr for EPSILON values, vec3, and spherical_voxel_grid.