### PR TITLE
Reduce floating point calculations in angular, azimuthal hit.

### DIFF
--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -45,13 +45,13 @@ struct Ray final {
       return (p[NZD_index_] - this->NZD_origin_) * this->NZD_inverse_direction_;
     }
 
-    inline BoundVec3 origin() const noexcept { return this->origin_; }
+    inline const BoundVec3 &origin() const noexcept { return this->origin_; }
 
-    inline FreeVec3 direction() const noexcept { return this->direction_; }
+    inline const FreeVec3 &direction() const noexcept { return this->direction_; }
 
-    inline FreeVec3 invDirection() const noexcept { return this->inverse_direction_; }
+    inline const FreeVec3 &invDirection() const noexcept { return this->inverse_direction_; }
 
-    inline UnitVec3 unitDirection() const noexcept { return this->unit_direction_; }
+    inline const UnitVec3 &unitDirection() const noexcept { return this->unit_direction_; }
 
 private:
     // The origin of the ray.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -100,11 +100,11 @@ namespace svr {
     // The collinear times are the two times possible for t, dependent on if the ray is collinear to the given
     // voxel boundary.
     struct RaySegment {
-        inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)) {}
+        inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)), ray(ray) {}
 
         // Updates the point P1 with the new time traversal time t. Similarly, updates the
         // segment denoted by P2 - P1.
-        inline void updateAtTime(double t, const Ray &ray) noexcept {
+        inline void updateRaySegmentAtTime(double t) noexcept {
             P1 = ray.pointAtParameter(t);
             ray_segment = P2 - P1;
         }
@@ -117,6 +117,8 @@ namespace svr {
 
         // P2 - P1.
         FreeVec3 ray_segment = FreeVec3(0.0, 0.0, 0.0);
+
+        Ray ray;
     };
 
     // Determines equality between two floating point numbers in two steps. First, it uses the absolute epsilon, then it
@@ -565,7 +567,7 @@ namespace svr {
         while (true) {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
             radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
-            ray_segment.updateAtTime(t, ray);
+            ray_segment.updateRaySegmentAtTime(t);
             const auto angular_params = angularHit(ray, grid, ray_segment, collinear_times,
                                                    current_voxel_ID_theta, t, t_end);
             const auto azimuthal_params = azimuthalHit(ray, grid, ray_segment, collinear_times,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -88,7 +88,8 @@ namespace svr {
         // Pre-initialized structures to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;
         std::vector<double> times_gt_t;
-        // The currentt state of the
+        // The current state of the previous_transition_flag. This is saved here so that it can be passed
+        // into the radial hit function with each traversal.
         bool previous_transition_flag;
     };
 
@@ -224,8 +225,8 @@ namespace svr {
         const bool is_not_tangential_hit = !(rdata.times_gt_t.size() >= 2 &&
                                              isKnEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
         return {.tMaxR=intersection_time,
-                .tStepR=step[1 * is_not_tangential_hit +
-                             (is_not_tangential_hit && !is_radial_transition && KnLessThan(r_new, current_radius))],
+                .tStepR=step[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
+                             !is_radial_transition && KnLessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds=KnLessThan(t, intersection_time) && KnLessThan(intersection_time, t_end)
         };

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -361,8 +361,9 @@ namespace svr {
         return {.tMaxTheta=params.tMax, .tStepTheta=params.tStep, .within_bounds=params.within_bounds};
     }
 
-    // Determines whether an azimuthal hit occurs for the given ray. An azimuthal hit is considered an intersection with
-    // the ray and an azimuthal section. The azimuthal sections live in the XZ plane.
+    // Determines whether an azimuthal hit occurs for the given ray. An azimuthal hit is
+    // considered an intersection with the ray and an azimuthal section.
+    // The azimuthal sections live in the XZ plane.
     AzimuthalHitParameters azimuthalHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
                                         const RaySegment &rs_data, const std::array<double, 2> &collinear_times,
                                         int current_voxel_ID_phi, double t, double t_end) noexcept {

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -85,6 +85,7 @@ namespace svr {
 
         // Pre-calculated data to be used when calculating a radial hit.
         double v, ray_sphere_vector_dot;
+
         // Pre-initialized structures to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;
         std::vector<double> times_gt_t;
@@ -100,12 +101,12 @@ namespace svr {
     // The collinear times are the two times possible for t, dependent on if the ray is collinear to the given
     // voxel boundary.
     struct RaySegment {
-        inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)), ray(ray) {}
+        inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)), ray(&ray) {}
 
         // Updates the point P1 with the new time traversal time t. Similarly, updates the
         // segment denoted by P2 - P1.
         inline void updateRaySegmentAtTime(double t) noexcept {
-            P1 = ray.pointAtParameter(t);
+            P1 = ray->pointAtParameter(t);
             ray_segment = P2 - P1;
         }
 
@@ -118,7 +119,7 @@ namespace svr {
         // P2 - P1.
         FreeVec3 ray_segment = FreeVec3(0.0, 0.0, 0.0);
 
-        Ray ray;
+        const Ray *ray;
     };
 
     // Determines equality between two floating point numbers in two steps. First, it uses the absolute epsilon, then it

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -6,7 +6,7 @@
 
 namespace svr {
     // An array of step values used to avoid branch prediction in radialHit().
-    constexpr std::array<int, 3> step{0, -1, 1};
+    constexpr std::array<int, 3> STEP{0, -1, 1};
 
     // Epsilons used for floating point comparisons in Knuth's algorithm.
     constexpr double ABS_EPSILON = 1e-12;
@@ -229,7 +229,7 @@ namespace svr {
         const bool is_not_tangential_hit = !(rdata.times_gt_t.size() >= 2 &&
                                              isKnEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
         return {.tMaxR=intersection_time,
-                .tStepR=step[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
+                .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
                              !is_radial_transition && KnLessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds=KnLessThan(t, intersection_time) && KnLessThan(intersection_time, t_end)

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -101,7 +101,7 @@ namespace svr {
     // The collinear times are the two times possible for t, dependent on if the ray is collinear to the given
     // voxel boundary.
     struct RaySegment {
-        inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)), ray(&ray) {}
+        inline RaySegment(const Ray *ray, double t_end) : P2(ray->pointAtParameter(t_end)), ray(ray) {}
 
         // Updates the point P1 with the new time traversal time t. Similarly, updates the
         // segment denoted by P2 - P1.
@@ -563,7 +563,7 @@ namespace svr {
         std::array<double, 2> collinear_times = {0.0, ray.timeOfIntersectionAt(grid.sphereCenter())};
 
         RadialHitData radial_hit_data(v, ray_sphere_vector_dot);
-        RaySegment ray_segment(ray, t_end);
+        RaySegment ray_segment(&ray, t_end);
 
         while (true) {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -80,14 +80,15 @@ namespace svr {
     // are used to determine the type of radial hit. Upon initialization, the previous transition flag is set to false.
     struct RadialHitData {
         inline RadialHitData(double t_v, double t_ray_sphere_vector_dot) :
-                v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot) {
-            times_gt_t.reserve(4);
-            previous_transition_flag = false;
-        }
+        v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot),
+        previous_transition_flag(false) { times_gt_t.reserve(4); }
 
+        // Pre-calculated data to be used when calculating a radial hit.
         double v, ray_sphere_vector_dot;
+        // Pre-initialized structures to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;
         std::vector<double> times_gt_t;
+        // The currentt state of the
         bool previous_transition_flag;
     };
 
@@ -98,15 +99,21 @@ namespace svr {
     // voxel boundary.
     struct RaySegment {
         inline RaySegment(const Ray &ray, double t_end) : P2(ray.pointAtParameter(t_end)) {}
-        // Updates the P1 point with the new time t. Similarly, updates the
-        // new segment free vector v.
-        inline void updateAtTime(double t, const Ray& ray) noexcept {
+
+        // Updates the point P1 with the new time traversal time t. Similarly, updates the
+        // segment denoted by P2 - P1.
+        inline void updateAtTime(double t, const Ray &ray) noexcept {
             P1 = ray.pointAtParameter(t);
             ray_segment = P2 - P1;
         }
 
+        // The begin point of the ray segment.
         BoundVec3 P1 = BoundVec3(0.0, 0.0, 0.0);
+
+        // The end point of the ray segment.
         BoundVec3 P2 = BoundVec3(0.0, 0.0, 0.0);
+
+        // P2 - P1.
         FreeVec3 ray_segment = FreeVec3(0.0, 0.0, 0.0);
     };
 
@@ -557,8 +564,10 @@ namespace svr {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
             radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
             ray_segment.updateAtTime(t, ray);
-            const auto angular_params = angularHit(ray, grid, ray_segment, collinear_times, current_voxel_ID_theta, t, t_end);
-            const auto azimuthal_params = azimuthalHit(ray, grid, ray_segment, collinear_times, current_voxel_ID_phi, t, t_end);
+            const auto angular_params = angularHit(ray, grid, ray_segment, collinear_times,
+                                                   current_voxel_ID_theta, t, t_end);
+            const auto azimuthal_params = azimuthalHit(ray, grid, ray_segment, collinear_times,
+                                                       current_voxel_ID_phi, t, t_end);
             const auto voxel_intersection = minimumIntersection(radial_params, angular_params, azimuthal_params);
             switch (voxel_intersection) {
                 case Radial: {

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -91,6 +91,32 @@ namespace svr {
         bool previous_transition_flag;
     };
 
+    // Pre-calculated information for the generalized plane hit function, which generalizes azimuthal and angular
+    // hits. Since the ray segment is dependent solely on time, this is unnecessary to calculate twice for each
+    // plane hit function. Here, v is the difference between ray_segment_end and ray_segment_begin.
+    // The collinear times are the two times possible for t, dependent on if the ray is collinear to the given
+    // voxel boundary.
+    struct GeneralizedPlaneHitData {
+        inline GeneralizedPlaneHitData(const Ray &ray, const SphericalVoxelGrid &grid, double t, double t_end) {
+            collinear_times = {0.0, ray.timeOfIntersectionAt(grid.sphereCenter())};
+            ray_segment_begin = ray.pointAtParameter(t);
+            ray_segment_end = ray.pointAtParameter(t_end);
+            v = ray_segment_end - ray_segment_begin;
+        }
+
+        // Updates the ray_segment_begin point with the new time t. Similarly, updates the
+        // new segment free vector v.
+        inline void updateRaySegmentPoints(const Ray& ray, double t) noexcept {
+            ray_segment_begin = ray.pointAtParameter(t);
+            v = ray_segment_end - ray_segment_begin;
+        }
+
+        std::array<double, 2> collinear_times;
+        BoundVec3 ray_segment_begin = BoundVec3(0.0, 0.0, 0.0);
+        BoundVec3 ray_segment_end = BoundVec3(0.0, 0.0, 0.0);
+        FreeVec3 v = FreeVec3(0.0, 0.0, 0.0);
+    };
+
     // Determines equality between two floating point numbers in two steps. First, it uses the absolute epsilon, then it
     // uses a modified version of an algorithm developed by Donald Knuth (which in turn relies upon relative epsilon).
     // Provides default values for the absolute and relative epsilon. The "Kn" in the function name is short for Knuth.
@@ -150,19 +176,19 @@ namespace svr {
     // as well as avoiding unnecessary duplicate calculations that have already been done in the initialization phase.
     // This follows closely the mathematics presented in:
     // http://cas.xav.free.fr/Graphics%20Gems%204%20-%20Paul%20S.%20Heckbert.pdf
-    RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid, RadialHitData &data,
+    RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid, RadialHitData &rdata,
                                   int current_voxel_ID_r, double t, double t_end) noexcept {
         const double current_radius = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
         double r_a = std::max(current_radius - grid.deltaRadius(), grid.deltaRadius());
         double r_b;
-        if (!data.previous_transition_flag) {
+        if (!rdata.previous_transition_flag) {
             // To find the next radius, we need to check the previous_transition_flag:
             // In the case that the ray has sequential hits with equal radii, e.g.
             // the innermost radial disc, this ensures that the proper radii are being checked.
             r_b = std::min(current_radius + grid.deltaRadius(), grid.sphereMaxRadius());
         } else { r_b = std::min(current_radius, grid.sphereMaxRadius()); }
         // Find the intersection times for the ray and the previous and next radial discs.
-        const double ray_sphere_dot_minus_v_squared = data.ray_sphere_vector_dot - data.v * data.v;
+        const double ray_sphere_dot_minus_v_squared = rdata.ray_sphere_vector_dot - rdata.v * rdata.v;
         double discriminant_a = r_a * r_a - ray_sphere_dot_minus_v_squared;
         if (discriminant_a < 0.0) {
             r_a += grid.deltaRadius();
@@ -170,40 +196,39 @@ namespace svr {
         }
         const double d_a = std::sqrt(discriminant_a);
 
-        data.intersection_times[0] = ray.timeOfIntersectionAt(data.v - d_a);
-        data.intersection_times[1] = ray.timeOfIntersectionAt(data.v + d_a);
+        rdata.intersection_times[0] = ray.timeOfIntersectionAt(rdata.v - d_a);
+        rdata.intersection_times[1] = ray.timeOfIntersectionAt(rdata.v + d_a);
+        rdata.intersection_times[2] = 0.0;
+        rdata.intersection_times[3] = 0.0;
 
         const double discriminant_b = r_b * r_b - ray_sphere_dot_minus_v_squared;
         if (discriminant_b >= 0.0) {
             const double d_b = std::sqrt(discriminant_b);
-            data.intersection_times[2] = ray.timeOfIntersectionAt(data.v - d_b);
-            data.intersection_times[3] = ray.timeOfIntersectionAt(data.v + d_b);
-        } else {
-            data.intersection_times[2] = 0.0;
-            data.intersection_times[3] = 0.0;
+            rdata.intersection_times[2] = ray.timeOfIntersectionAt(rdata.v - d_b);
+            rdata.intersection_times[3] = ray.timeOfIntersectionAt(rdata.v + d_b);
         }
-        data.times_gt_t.clear();
-        std::copy_if(data.intersection_times.cbegin(), data.intersection_times.cend(),
-                     std::back_inserter(data.times_gt_t), [t](double i) { return i > t; });
+        rdata.times_gt_t.clear();
+        std::copy_if(rdata.intersection_times.cbegin(), rdata.intersection_times.cend(),
+                     std::back_inserter(rdata.times_gt_t), [t](double i) { return i > t; });
 
-        if (data.times_gt_t.empty()) {
+        if (rdata.times_gt_t.empty()) {
             // No intersection.
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
                     .previous_transition_flag=false,
                     .within_bounds=false};
         }
-        const double intersection_time = data.times_gt_t[0];
+        const double intersection_time = rdata.times_gt_t[0];
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
-        const bool is_not_tangential_hit = !(data.times_gt_t.size() >= 2 &&
-                                             isKnEqual(data.intersection_times[0], data.intersection_times[1]));
+        const bool is_not_tangential_hit = !(rdata.times_gt_t.size() >= 2 &&
+                                             isKnEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
         return {.tMaxR=intersection_time,
                 .tStepR=step[1 * is_not_tangential_hit +
                              (is_not_tangential_hit && !is_radial_transition && KnLessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds=KnLessThan(t, intersection_time) && KnLessThan(intersection_time, t_end)
-                };
+        };
     }
 
     // A generalized version of the latter half of the angular and azimuthal hit parameters. Since the only difference
@@ -215,27 +240,28 @@ namespace svr {
     GenHitParameters
     generalizedPlaneHit(const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min, double perp_uv_max,
                         double perp_uw_min, double perp_uw_max, double perp_vw_min, double perp_vw_max,
-                        const BoundVec3 &p, const FreeVec3 &v, double t, double t_end,
+                        const GeneralizedPlaneHitData &data, double t, double t_end,
                         double ray_plane_direction, double sphere_plane_center,
-                        const std::array<double, 2> &collinear_times,
                         const std::vector<svr::LineSegment> &P_max, int current_voxel_ID) noexcept {
         const bool is_parallel_min = isKnEqual(perp_uv_min, 0.0);
         const bool is_collinear_min = is_parallel_min && isKnEqual(perp_uw_min, 0.0) && isKnEqual(perp_vw_min, 0.0);
         const bool is_parallel_max = isKnEqual(perp_uv_max, 0.0);
         const bool is_collinear_max = is_parallel_max && isKnEqual(perp_uw_max, 0.0) && isKnEqual(perp_vw_max, 0.0);
-        double t_min = collinear_times[is_collinear_min];
-        bool is_intersect_min = false;
         double a, b;
+        double t_min = data.collinear_times[is_collinear_min];
+        bool is_intersect_min = false;
         if (!is_parallel_min) {
             const double inv_perp_uv_min = 1.0 / perp_uv_min;
             a = perp_vw_min * inv_perp_uv_min;
             b = perp_uw_min * inv_perp_uv_min;
             if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
                 is_intersect_min = true;
-                t_min = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+                t_min = ray.timeOfIntersectionAt(Vec3(data.ray_segment_begin.x() + data.v.x() * b,
+                                                      data.ray_segment_begin.y() + data.v.y() * b,
+                                                      data.ray_segment_begin.z() + data.v.z() * b));
             }
         }
-        double t_max = collinear_times[is_collinear_max];
+        double t_max = data.collinear_times[is_collinear_max];
         bool is_intersect_max = false;
         if (!is_parallel_max) {
             const double inv_perp_uv_max = 1.0 / perp_uv_max;
@@ -243,7 +269,9 @@ namespace svr {
             b = perp_uw_max * inv_perp_uv_max;
             if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
                 is_intersect_max = true;
-                t_max = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+                t_max = ray.timeOfIntersectionAt(Vec3(data.ray_segment_begin.x() + data.v.x() * b,
+                                                      data.ray_segment_begin.y() + data.v.y() * b,
+                                                      data.ray_segment_begin.z() + data.v.z() * b));
             }
         }
         GenHitParameters params;
@@ -303,13 +331,8 @@ namespace svr {
     // Determines whether an angular hit occurs for the given ray. An angular hit is considered an intersection with
     // the ray and an angular section. The angular sections live in the XY plane.
     AngularHitParameters angularHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                    const std::array<double, 2> &collinear_times,
+                                    const GeneralizedPlaneHitData &data,
                                     int current_voxel_ID_theta, double t, double t_end) noexcept {
-        // Ray segment vector.
-        const BoundVec3 p = ray.pointAtParameter(t);
-        const BoundVec3 p_end = ray.pointAtParameter(t_end);
-        const FreeVec3 v = p_end - p;
-
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxAngular(current_voxel_ID_theta).P1,
                              grid.pMaxAngular(current_voxel_ID_theta).P2, 0.0);
@@ -317,32 +340,26 @@ namespace svr {
                              grid.pMaxAngular(current_voxel_ID_theta + 1).P2, 0.0);
         const BoundVec3 u_min = grid.sphereCenter() - p_one;
         const BoundVec3 u_max = grid.sphereCenter() - p_two;
-        const FreeVec3 w_min = p_one - FreeVec3(p);
-        const FreeVec3 w_max = p_two - FreeVec3(p);
-        const double perp_uv_min = u_min.x() * v.y() - u_min.y() * v.x();
-        const double perp_uv_max = u_max.x() * v.y() - u_max.y() * v.x();
+        const FreeVec3 w_min = p_one - FreeVec3(data.ray_segment_begin);
+        const FreeVec3 w_max = p_two - FreeVec3(data.ray_segment_begin);
+        const double perp_uv_min = u_min.x() * data.v.y() - u_min.y() * data.v.x();
+        const double perp_uv_max = u_max.x() * data.v.y() - u_max.y() * data.v.x();
         const double perp_uw_min = u_min.x() * w_min.y() - u_min.y() * w_min.x();
         const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
-        const double perp_vw_min = v.x() * w_min.y() - v.y() * w_min.x();
-        const double perp_vw_max = v.x() * w_max.y() - v.y() * w_max.x();
+        const double perp_vw_min = data.v.x() * w_min.y() - data.v.y() * w_min.x();
+        const double perp_vw_max = data.v.x() * w_max.y() - data.v.y() * w_max.x();
         const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
-                                                            perp_uw_max,
-                                                            perp_vw_min, perp_vw_max, p, v, t, t_end,
+                                                            perp_uw_max, perp_vw_min, perp_vw_max, data, t, t_end,
                                                             ray.direction().y(), grid.sphereCenter().y(),
-                                                            collinear_times, grid.pMaxAngular(),
-                                                            current_voxel_ID_theta);
+                                                            grid.pMaxAngular(), current_voxel_ID_theta);
         return {.tMaxTheta=params.tMax, .tStepTheta=params.tStep, .within_bounds=params.within_bounds};
     }
 
     // Determines whether an azimuthal hit occurs for the given ray. An azimuthal hit is considered an intersection with
     // the ray and an azimuthal section. The azimuthal sections live in the XZ plane.
     AzimuthalHitParameters azimuthalHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                        const std::array<double, 2> &collinear_times,
+                                        const GeneralizedPlaneHitData &data,
                                         int current_voxel_ID_phi, double t, double t_end) noexcept {
-        // Ray segment vector.
-        const BoundVec3 p = ray.pointAtParameter(t);
-        const BoundVec3 p_end = ray.pointAtParameter(t_end);
-        const FreeVec3 v = p_end - p;
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxAzimuthal(current_voxel_ID_phi).P1, 0.0,
                              grid.pMaxAzimuthal(current_voxel_ID_phi).P2);
@@ -350,20 +367,18 @@ namespace svr {
                              grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P2);
         const BoundVec3 u_min = grid.sphereCenter() - p_one;
         const BoundVec3 u_max = grid.sphereCenter() - p_two;
-        const FreeVec3 w_min = p_one - FreeVec3(p);
-        const FreeVec3 w_max = p_two - FreeVec3(p);
-        const double perp_uv_min = u_min.x() * v.z() - u_min.z() * v.x();
-        const double perp_uv_max = u_max.x() * v.z() - u_max.z() * v.x();
+        const FreeVec3 w_min = p_one - FreeVec3(data.ray_segment_begin);
+        const FreeVec3 w_max = p_two - FreeVec3(data.ray_segment_begin);
+        const double perp_uv_min = u_min.x() * data.v.z() - u_min.z() * data.v.x();
+        const double perp_uv_max = u_max.x() * data.v.z() - u_max.z() * data.v.x();
         const double perp_uw_min = u_min.x() * w_min.z() - u_min.z() * w_min.x();
         const double perp_uw_max = u_max.x() * w_max.z() - u_max.z() * w_max.x();
-        const double perp_vw_min = v.x() * w_min.z() - v.z() * w_min.x();
-        const double perp_vw_max = v.x() * w_max.z() - v.z() * w_max.x();
+        const double perp_vw_min = data.v.x() * w_min.z() - data.v.z() * w_min.x();
+        const double perp_vw_max = data.v.x() * w_max.z() - data.v.z() * w_max.x();
         const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
-                                                            perp_uw_max,
-                                                            perp_vw_min, perp_vw_max, p, v, t, t_end,
+                                                            perp_uw_max, perp_vw_min, perp_vw_max, data, t, t_end,
                                                             ray.direction().z(), grid.sphereCenter().z(),
-                                                            collinear_times, grid.pMaxAzimuthal(),
-                                                            current_voxel_ID_phi);
+                                                            grid.pMaxAzimuthal(), current_voxel_ID_phi);
         return {.tMaxPhi=params.tMax, .tStepPhi=params.tStep, .within_bounds=params.within_bounds};
     }
 
@@ -384,15 +399,15 @@ namespace svr {
                                                      const AngularHitParameters &ang_params,
                                                      const AzimuthalHitParameters &azi_params) noexcept {
         if (rad_params.within_bounds && KnLessThan(rad_params.tMaxR, ang_params.tMaxTheta)
-                                     && KnLessThan(rad_params.tMaxR, azi_params.tMaxPhi)) {
+            && KnLessThan(rad_params.tMaxR, azi_params.tMaxPhi)) {
             return VoxelIntersectionType::Radial;
         }
         if (ang_params.within_bounds && KnLessThan(ang_params.tMaxTheta, rad_params.tMaxR)
-                                     && KnLessThan(ang_params.tMaxTheta, azi_params.tMaxPhi)) {
+            && KnLessThan(ang_params.tMaxTheta, azi_params.tMaxPhi)) {
             return VoxelIntersectionType::Angular;
         }
         if (azi_params.within_bounds && KnLessThan(azi_params.tMaxPhi, ang_params.tMaxTheta)
-                                     && KnLessThan(azi_params.tMaxPhi, rad_params.tMaxR)) {
+            && KnLessThan(azi_params.tMaxPhi, rad_params.tMaxR)) {
             return VoxelIntersectionType::Azimuthal;
         }
         if (rad_params.within_bounds && isKnEqual(rad_params.tMaxR, ang_params.tMaxTheta)
@@ -416,33 +431,32 @@ namespace svr {
     // these points with a given radius 'current_radius'. The case where the number of angular voxels is
     // equal to the number of azimuthal voxels is also checked to reduce the number of trigonometric
     // and floating point calculations.
-	inline void initializeVoxelBoundarySegments(std::vector<svr::LineSegment> &P_angular,
-												std::vector<svr::LineSegment> &P_azimuthal,
-												const svr::SphericalVoxelGrid &grid, double current_radius) noexcept {
-		if (grid.numAngularVoxels() == grid.numAzimuthalVoxels()) {
-			std::transform(grid.angularTrigValues().cbegin(), grid.angularTrigValues().cend(),
-						   P_angular.begin(),
-						   P_azimuthal.begin(),
-						   [current_radius, &grid](const TrigonometricValues &tv,
-												   LineSegment &angular_LS) -> LineSegment {
-							 const double px_value = current_radius * tv.cosine + grid.sphereCenter().x();
-							 const double current_radius_times_sin = current_radius * tv.sine;
-							 angular_LS = {.P1=px_value, .P2=current_radius_times_sin + grid.sphereCenter().y()};
-							 return {.P1=px_value, .P2=current_radius_times_sin + grid.sphereCenter().z()};
-						   });
-			return;
-		}
-		std::transform(grid.angularTrigValues().cbegin(), grid.angularTrigValues().cend(), P_angular.begin(),
-					   [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
-						 return {.P1=current_radius * tv.cosine + grid.sphereCenter().x(),
-							     .P2=current_radius * tv.sine + grid.sphereCenter().y()};
-					   });
-		std::transform(grid.azimuthalTrigValues().cbegin(), grid.azimuthalTrigValues().cend(), P_azimuthal.begin(),
-					   [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
-						 return {.P1=current_radius * tv.cosine + grid.sphereCenter().x(),
-							     .P2=current_radius * tv.sine + grid.sphereCenter().z()};
-					   });
-	}
+    inline void initializeVoxelBoundarySegments(std::vector<svr::LineSegment> &P_angular,
+                                                std::vector<svr::LineSegment> &P_azimuthal,
+                                                const svr::SphericalVoxelGrid &grid, double current_radius) noexcept {
+        if (grid.numAngularVoxels() == grid.numAzimuthalVoxels()) {
+            std::transform(grid.angularTrigValues().cbegin(), grid.angularTrigValues().cend(),
+                           P_angular.begin(), P_azimuthal.begin(),
+                           [current_radius, &grid](const TrigonometricValues &tv,
+                                                   LineSegment &angular_LS) -> LineSegment {
+                               const double px_value = current_radius * tv.cosine + grid.sphereCenter().x();
+                               const double current_radius_times_sin = current_radius * tv.sine;
+                               angular_LS = {.P1=px_value, .P2=current_radius_times_sin + grid.sphereCenter().y()};
+                               return {.P1=px_value, .P2=current_radius_times_sin + grid.sphereCenter().z()};
+                           });
+            return;
+        }
+        std::transform(grid.angularTrigValues().cbegin(), grid.angularTrigValues().cend(), P_angular.begin(),
+                       [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
+                           return {.P1=current_radius * tv.cosine + grid.sphereCenter().x(),
+                                   .P2=current_radius * tv.sine + grid.sphereCenter().y()};
+                       });
+        std::transform(grid.azimuthalTrigValues().cbegin(), grid.azimuthalTrigValues().cend(), P_azimuthal.begin(),
+                       [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
+                           return {.P1=current_radius * tv.cosine + grid.sphereCenter().x(),
+                                   .P2=current_radius * tv.sine + grid.sphereCenter().z()};
+                       });
+    }
 
     std::vector<svr::SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray,
                                                                        const svr::SphericalVoxelGrid &grid,
@@ -539,14 +553,12 @@ namespace svr {
         t_end = std::min(t_grid_exit, t_end);
 
         RadialHitData radial_hit_data(v, ray_sphere_vector_dot);
-        const std::array<double, 2> collinear_times = {0.0, ray.timeOfIntersectionAt(grid.sphereCenter())};
-
+        GeneralizedPlaneHitData plane_hit_data(ray, grid, t, t_end);
         while (true) {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
             radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
-
-            const auto angular_params = angularHit(ray, grid, collinear_times, current_voxel_ID_theta, t, t_end);
-            const auto azimuthal_params = azimuthalHit(ray, grid, collinear_times, current_voxel_ID_phi, t, t_end);
+            const auto angular_params = angularHit(ray, grid, plane_hit_data, current_voxel_ID_theta, t, t_end);
+            const auto azimuthal_params = azimuthalHit(ray, grid, plane_hit_data, current_voxel_ID_phi, t, t_end);
             const auto voxel_intersection = minimumIntersection(radial_params, angular_params, azimuthal_params);
             switch (voxel_intersection) {
                 case Radial: {
@@ -601,6 +613,7 @@ namespace svr {
                     return voxels;
                 }
             }
+            plane_hit_data.updateRaySegmentPoints(ray, t);c
             voxels.push_back({.radial_voxel=current_voxel_ID_r,
                               .angular_voxel=current_voxel_ID_theta,
                               .azimuthal_voxel=current_voxel_ID_phi});

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -88,6 +88,7 @@ namespace svr {
         // Pre-initialized structures to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;
         std::vector<double> times_gt_t;
+
         // The current state of the previous_transition_flag. This is saved here so that it can be passed
         // into the radial hit function with each traversal.
         bool previous_transition_flag;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -31,21 +31,17 @@ struct SphericalVoxelGrid {
  public:
   SphericalVoxelGrid(const BoundVec3 &min_bound, const BoundVec3 &max_bound, std::size_t num_radial_voxels,
 					 std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels,
-					 const BoundVec3 &sphere_center,
-					 double sphere_max_radius) :
+					 const BoundVec3 &sphere_center, double sphere_max_radius) :
 	  min_bound_(min_bound),
 	  max_bound_(max_bound),
 	  num_radial_voxels_(num_radial_voxels),
 	  num_angular_voxels_(num_angular_voxels),
 	  num_azimuthal_voxels_(num_azimuthal_voxels),
-	  inv_num_radial_voxels_(1.0 / num_radial_voxels),
-	  inv_num_angular_voxels_(1.0 / num_angular_voxels),
-	  inv_num_azimuthal_voxels_(1.0 / num_azimuthal_voxels),
 	  sphere_center_(sphere_center),
 	  sphere_max_radius_(sphere_max_radius),
-	  delta_radius_(sphere_max_radius * inv_num_radial_voxels_),
-	  delta_theta_(2 * M_PI * inv_num_angular_voxels_),
-	  delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
+	  delta_radius_(sphere_max_radius / num_radial_voxels),
+	  delta_theta_(2 * M_PI / num_angular_voxels),
+	  delta_phi_(2 * M_PI / num_azimuthal_voxels),
 	  inv_delta_radius_(1.0 / delta_radius_),
 	  inv_delta_theta_(1.0 / delta_theta_),
 	  inv_delta_phi_(1.0 / delta_phi_) {
@@ -103,71 +99,43 @@ struct SphericalVoxelGrid {
 					 });
   }
 
-  inline std::size_t
-  numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
+  inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
 
-  inline std::size_t
-  numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
+  inline std::size_t numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
 
-  inline std::size_t
-  numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
+  inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
 
-  inline double
-  invNumRadialVoxels() const noexcept { return this->inv_num_radial_voxels_; }
+  inline const BoundVec3& minBound() const noexcept { return this->min_bound_; }
 
-  inline double
-  invNumAngularVoxels() const noexcept { return this->inv_num_angular_voxels_; }
+  inline const BoundVec3& maxBound() const noexcept { return this->max_bound_; }
 
-  inline double
-  invNumAzimuthalVoxels() const noexcept { return this->inv_num_azimuthal_voxels_; }
+  inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
-  inline BoundVec3
-  minBound() const noexcept { return this->min_bound_; }
+  inline const BoundVec3& sphereCenter() const noexcept { return this->sphere_center_; }
 
-  inline BoundVec3
-  maxBound() const noexcept { return this->max_bound_; }
+  inline double deltaRadius() const noexcept { return this->delta_radius_; }
 
-  inline double
-  sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
+  inline double deltaTheta() const noexcept { return this->delta_theta_; }
 
-  inline BoundVec3
-  sphereCenter() const noexcept { return this->sphere_center_; }
+  inline double deltaPhi() const noexcept { return this->delta_phi_; }
 
-  inline double
-  deltaRadius() const noexcept { return this->delta_radius_; }
+  inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
 
-  inline double
-  deltaTheta() const noexcept { return this->delta_theta_; }
+  inline double invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
 
-  inline double
-  deltaPhi() const noexcept { return this->delta_phi_; }
+  inline double invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
 
-  inline double
-  invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
+  inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
-  inline double
-  invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
+  inline const std::vector<LineSegment> & pMaxAngular() const noexcept { return this->P_max_angular_; }
 
-  inline double
-  invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
+  inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
-  inline const LineSegment &
-  pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
+  inline const std::vector<LineSegment> &pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
 
-  inline const std::vector<LineSegment> &
-  pMaxAngular() const noexcept { return this->P_max_angular_; }
+  inline const std::vector<TrigonometricValues> &angularTrigValues() const noexcept { return angular_trig_values_; }
 
-  inline const LineSegment &
-  pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
-
-  inline const std::vector<LineSegment> &
-  pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
-
-  inline const std::vector<TrigonometricValues> &
-  angularTrigValues() const noexcept { return angular_trig_values_; }
-
-  inline const std::vector<TrigonometricValues> &
-  azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
+  inline const std::vector<TrigonometricValues> &azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
 
  private:
   // The minimum bound vector of the voxel grid.
@@ -178,9 +146,6 @@ struct SphericalVoxelGrid {
 
   // The number of radial, angular, and azimuthal voxels.
   const std::size_t num_radial_voxels_, num_angular_voxels_, num_azimuthal_voxels_;
-
-  // Similar to num_x_voxels, but 1 / x, where x is the number of voxels.
-  const double inv_num_radial_voxels_, inv_num_angular_voxels_, inv_num_azimuthal_voxels_;
 
   // The center of the sphere.
   const BoundVec3 sphere_center_;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 namespace svr {
+    constexpr double tau = 2 * M_PI;
 
 // Represents a line segment. This is used to represent the points of intersections between
 // the lines corresponding to voxel boundaries and a given radial voxel.
@@ -40,11 +41,9 @@ struct SphericalVoxelGrid {
 	  sphere_center_(sphere_center),
 	  sphere_max_radius_(sphere_max_radius),
 	  delta_radius_(sphere_max_radius / num_radial_voxels),
-	  delta_theta_(2 * M_PI / num_angular_voxels),
-	  delta_phi_(2 * M_PI / num_azimuthal_voxels),
-	  inv_delta_radius_(1.0 / delta_radius_),
-	  inv_delta_theta_(1.0 / delta_theta_),
-	  inv_delta_phi_(1.0 / delta_phi_) {
+	  delta_theta_(tau / num_angular_voxels),
+	  delta_phi_(tau / num_azimuthal_voxels),
+	  inv_delta_radius_(1.0 / delta_radius_) {
 
 	  P_max_angular_.resize(num_angular_voxels + 1);
 	  P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
@@ -115,19 +114,11 @@ struct SphericalVoxelGrid {
 
   inline double deltaRadius() const noexcept { return this->delta_radius_; }
 
-  inline double deltaTheta() const noexcept { return this->delta_theta_; }
-
-  inline double deltaPhi() const noexcept { return this->delta_phi_; }
-
   inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
-
-  inline double invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
-
-  inline double invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
 
   inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
-  inline const std::vector<LineSegment> & pMaxAngular() const noexcept { return this->P_max_angular_; }
+  inline const std::vector<LineSegment> &pMaxAngular() const noexcept { return this->P_max_angular_; }
 
   inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
@@ -160,7 +151,7 @@ struct SphericalVoxelGrid {
   const double delta_theta_, delta_phi_;
 
   // Inverse of the above delta values.
-  const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
+  const double inv_delta_radius_;
 
   // The maximum radius line segments for angular voxels.
   std::vector<LineSegment> P_max_angular_;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -94,7 +94,7 @@ struct SphericalVoxelGrid {
 	  std::transform(angular_trig_values_.cbegin(), angular_trig_values_.cend(), P_max_angular_.begin(),
 					 [&](const TrigonometricValues &ang_tv) -> LineSegment {
 					   return {.P1=sphere_max_radius * ang_tv.cosine + sphere_center.x(),
-						       .P2= sphere_max_radius * ang_tv.sine + sphere_center.y()};
+						       .P2=sphere_max_radius * ang_tv.sine + sphere_center.y()};
 					 });
 	  std::transform(azimuthal_trig_values_.cbegin(), azimuthal_trig_values_.cend(), P_max_azimuthal_.begin(),
 					 [&](const TrigonometricValues &azi_tv) -> LineSegment {

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -7,165 +7,167 @@
 namespace svr {
     constexpr double TAU = 2 * M_PI;
 
-// Represents a line segment. This is used to represent the points of intersections between
-// the lines corresponding to voxel boundaries and a given radial voxel.
-struct LineSegment {
-  double P1;
-  double P2;
-};
+    // Represents a line segment. This is used to represent the points of intersections between
+    // the lines corresponding to voxel boundaries and a given radial voxel.
+    struct LineSegment {
+        double P1;
+        double P2;
+    };
 
-// The trigonometric values for a given radian.
-struct TrigonometricValues {
-  double cosine;
-  double sine;
-};
+    // The trigonometric values for a given radian.
+    struct TrigonometricValues {
+        double cosine;
+        double sine;
+    };
 
-// Represents a 3-dimensional spherical voxel grid. The minimum and maximum bounds [min_bound_, max_bound_]
-// contain the entirety of the sphere that is to be traversed.
-// Requires:
-//   max_bound > min_bound
-//   num_radial_voxels > 0
-//   num_angular_voxels > 0
-//   num_azimuthal_voxels > 0
-//   sphere_max_radius > 0.0
-struct SphericalVoxelGrid {
- public:
-  SphericalVoxelGrid(const BoundVec3 &min_bound, const BoundVec3 &max_bound, std::size_t num_radial_voxels,
-					 std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels,
-					 const BoundVec3 &sphere_center, double sphere_max_radius) :
-	  min_bound_(min_bound),
-	  max_bound_(max_bound),
-	  num_radial_voxels_(num_radial_voxels),
-	  num_angular_voxels_(num_angular_voxels),
-	  num_azimuthal_voxels_(num_azimuthal_voxels),
-	  sphere_center_(sphere_center),
-	  sphere_max_radius_(sphere_max_radius),
-	  delta_radius_(sphere_max_radius / num_radial_voxels),
-	  delta_theta_(TAU / num_angular_voxels),
-	  delta_phi_(TAU / num_azimuthal_voxels),
-	  inv_delta_radius_(1.0 / delta_radius_) {
+    // Represents a 3-dimensional spherical voxel grid. The minimum and maximum bounds [min_bound_, max_bound_]
+    // contain the entirety of the sphere that is to be traversed.
+    // Requires:
+    //   max_bound > min_bound
+    //   num_radial_voxels > 0
+    //   num_angular_voxels > 0
+    //   num_azimuthal_voxels > 0
+    //   sphere_max_radius > 0.0
+    struct SphericalVoxelGrid {
+    public:
+        SphericalVoxelGrid(const BoundVec3 &min_bound, const BoundVec3 &max_bound, std::size_t num_radial_voxels,
+                           std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels,
+                           const BoundVec3 &sphere_center, double sphere_max_radius) :
+                min_bound_(min_bound),
+                max_bound_(max_bound),
+                num_radial_voxels_(num_radial_voxels),
+                num_angular_voxels_(num_angular_voxels),
+                num_azimuthal_voxels_(num_azimuthal_voxels),
+                sphere_center_(sphere_center),
+                sphere_max_radius_(sphere_max_radius),
+                delta_radius_(sphere_max_radius / num_radial_voxels),
+                delta_theta_(TAU / num_angular_voxels),
+                delta_phi_(TAU / num_azimuthal_voxels),
+                inv_delta_radius_(1.0 / delta_radius_) {
 
-	  P_max_angular_.resize(num_angular_voxels + 1);
-	  P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
+            P_max_angular_.resize(num_angular_voxels + 1);
+            P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
 
-	  if (num_angular_voxels == num_azimuthal_voxels) {
-		  double radians = 0.0;
-		  angular_trig_values_.resize(num_angular_voxels + 1);
-		  std::generate(angular_trig_values_.begin(), angular_trig_values_.end(),
-						[&]() -> TrigonometricValues {
-						  const double cos = std::cos(radians);
-						  const double sin = std::sin(radians);
-						  radians += delta_theta_;
-						  return {.cosine=cos, .sine=sin};
-						});
-		  std::transform(angular_trig_values_.cbegin(), angular_trig_values_.cend(),
-						 P_max_angular_.begin(),
-						 P_max_azimuthal_.begin(),
-						 [&](const TrigonometricValues &tv, LineSegment &ang_LS) -> LineSegment {
-						   const double px_max_value = sphere_max_radius * tv.cosine + sphere_center.x();
-						   const double max_radius_times_s = sphere_max_radius * tv.sine;
-						   ang_LS = {.P1=px_max_value, .P2=max_radius_times_s + sphere_center.y()};
-						   return {.P1=px_max_value, .P2=max_radius_times_s + sphere_center.z()};
-						 });
-		  return;
-	  }
+            if (num_angular_voxels == num_azimuthal_voxels) {
+                double radians = 0.0;
+                angular_trig_values_.resize(num_angular_voxels + 1);
+                std::generate(angular_trig_values_.begin(), angular_trig_values_.end(),
+                              [&]() -> TrigonometricValues {
+                                  const double cos = std::cos(radians);
+                                  const double sin = std::sin(radians);
+                                  radians += delta_theta_;
+                                  return {.cosine=cos, .sine=sin};
+                              });
+                std::transform(angular_trig_values_.cbegin(), angular_trig_values_.cend(),
+                               P_max_angular_.begin(),
+                               P_max_azimuthal_.begin(),
+                               [&](const TrigonometricValues &tv, LineSegment &ang_LS) -> LineSegment {
+                                   const double px_max_value = sphere_max_radius * tv.cosine + sphere_center.x();
+                                   const double max_radius_times_s = sphere_max_radius * tv.sine;
+                                   ang_LS = {.P1=px_max_value, .P2=max_radius_times_s + sphere_center.y()};
+                                   return {.P1=px_max_value, .P2=max_radius_times_s + sphere_center.z()};
+                               });
+                return;
+            }
 
-	  double radians = 0.0;
-	  angular_trig_values_.resize(num_angular_voxels + 1);
-	  std::generate(angular_trig_values_.begin(), angular_trig_values_.end(), [&]() -> TrigonometricValues {
-		const double cos = std::cos(radians);
-		const double sin = std::sin(radians);
-		radians += delta_theta_;
-		return {.cosine=cos, .sine=sin};
-	  });
-	  radians = 0.0;
-	  azimuthal_trig_values_.resize(num_azimuthal_voxels + 1);
-	  std::generate(azimuthal_trig_values_.begin(), azimuthal_trig_values_.end(), [&]() -> TrigonometricValues {
-		const double cos = std::cos(radians);
-		const double sin = std::sin(radians);
-		radians += delta_phi_;
-		return {.cosine=cos, .sine=sin};
-	  });
-	  std::transform(angular_trig_values_.cbegin(), angular_trig_values_.cend(), P_max_angular_.begin(),
-					 [&](const TrigonometricValues &ang_tv) -> LineSegment {
-					   return {.P1=sphere_max_radius * ang_tv.cosine + sphere_center.x(),
-						       .P2=sphere_max_radius * ang_tv.sine + sphere_center.y()};
-					 });
-	  std::transform(azimuthal_trig_values_.cbegin(), azimuthal_trig_values_.cend(), P_max_azimuthal_.begin(),
-					 [&](const TrigonometricValues &azi_tv) -> LineSegment {
-					   return {.P1=sphere_max_radius * azi_tv.cosine + sphere_center.x(),
-						       .P2=sphere_max_radius * azi_tv.sine + sphere_center.z()};
-					 });
-  }
+            double radians = 0.0;
+            angular_trig_values_.resize(num_angular_voxels + 1);
+            std::generate(angular_trig_values_.begin(), angular_trig_values_.end(), [&]() -> TrigonometricValues {
+                const double cos = std::cos(radians);
+                const double sin = std::sin(radians);
+                radians += delta_theta_;
+                return {.cosine=cos, .sine=sin};
+            });
+            radians = 0.0;
+            azimuthal_trig_values_.resize(num_azimuthal_voxels + 1);
+            std::generate(azimuthal_trig_values_.begin(), azimuthal_trig_values_.end(), [&]() -> TrigonometricValues {
+                const double cos = std::cos(radians);
+                const double sin = std::sin(radians);
+                radians += delta_phi_;
+                return {.cosine=cos, .sine=sin};
+            });
+            std::transform(angular_trig_values_.cbegin(), angular_trig_values_.cend(), P_max_angular_.begin(),
+                           [&](const TrigonometricValues &ang_tv) -> LineSegment {
+                               return {.P1=sphere_max_radius * ang_tv.cosine + sphere_center.x(),
+                                       .P2=sphere_max_radius * ang_tv.sine + sphere_center.y()};
+                           });
+            std::transform(azimuthal_trig_values_.cbegin(), azimuthal_trig_values_.cend(), P_max_azimuthal_.begin(),
+                           [&](const TrigonometricValues &azi_tv) -> LineSegment {
+                               return {.P1=sphere_max_radius * azi_tv.cosine + sphere_center.x(),
+                                       .P2=sphere_max_radius * azi_tv.sine + sphere_center.z()};
+                           });
+        }
 
-  inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
+        inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
 
-  inline std::size_t numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
+        inline std::size_t numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
 
-  inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
+        inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
 
-  inline const BoundVec3& minBound() const noexcept { return this->min_bound_; }
+        inline const BoundVec3 &minBound() const noexcept { return this->min_bound_; }
 
-  inline const BoundVec3& maxBound() const noexcept { return this->max_bound_; }
+        inline const BoundVec3 &maxBound() const noexcept { return this->max_bound_; }
 
-  inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
+        inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
-  inline const BoundVec3& sphereCenter() const noexcept { return this->sphere_center_; }
+        inline const BoundVec3 &sphereCenter() const noexcept { return this->sphere_center_; }
 
-  inline double deltaRadius() const noexcept { return this->delta_radius_; }
+        inline double deltaRadius() const noexcept { return this->delta_radius_; }
 
-  inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
+        inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
 
-  inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
+        inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
-  inline const std::vector<LineSegment> &pMaxAngular() const noexcept { return this->P_max_angular_; }
+        inline const std::vector<LineSegment> &pMaxAngular() const noexcept { return this->P_max_angular_; }
 
-  inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
+        inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
-  inline const std::vector<LineSegment> &pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
+        inline const std::vector<LineSegment> &pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
 
-  inline const std::vector<TrigonometricValues> &angularTrigValues() const noexcept { return angular_trig_values_; }
+        inline const std::vector<TrigonometricValues> &
+        angularTrigValues() const noexcept { return angular_trig_values_; }
 
-  inline const std::vector<TrigonometricValues> &azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
+        inline const std::vector<TrigonometricValues> &
+                azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
 
- private:
-  // The minimum bound vector of the voxel grid.
-  const BoundVec3 min_bound_;
+    private:
+        // The minimum bound vector of the voxel grid.
+        const BoundVec3 min_bound_;
 
-  // The maximum bound vector of the voxel grid.
-  const BoundVec3 max_bound_;
+        // The maximum bound vector of the voxel grid.
+        const BoundVec3 max_bound_;
 
-  // The number of radial, angular, and azimuthal voxels.
-  const std::size_t num_radial_voxels_, num_angular_voxels_, num_azimuthal_voxels_;
+        // The number of radial, angular, and azimuthal voxels.
+        const std::size_t num_radial_voxels_, num_angular_voxels_, num_azimuthal_voxels_;
 
-  // The center of the sphere.
-  const BoundVec3 sphere_center_;
+        // The center of the sphere.
+        const BoundVec3 sphere_center_;
 
-  // The maximum radius of the sphere.
-  const double sphere_max_radius_;
+        // The maximum radius of the sphere.
+        const double sphere_max_radius_;
 
-  // The maximum sphere radius divided by the number of radial sections.
-  const double delta_radius_;
+        // The maximum sphere radius divided by the number of radial sections.
+        const double delta_radius_;
 
-  // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
-  const double delta_theta_, delta_phi_;
+        // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
+        const double delta_theta_, delta_phi_;
 
-  // Inverse of the above delta values.
-  const double inv_delta_radius_;
+        // Inverse of the above delta values.
+        const double inv_delta_radius_;
 
-  // The maximum radius line segments for angular voxels.
-  std::vector<LineSegment> P_max_angular_;
+        // The maximum radius line segments for angular voxels.
+        std::vector<LineSegment> P_max_angular_;
 
-  // The maximum radius line segments for azimuthal voxels.
-  std::vector<LineSegment> P_max_azimuthal_;
+        // The maximum radius line segments for azimuthal voxels.
+        std::vector<LineSegment> P_max_azimuthal_;
 
-  // The trigonometric values for each delta theta.
-  std::vector<TrigonometricValues> angular_trig_values_;
+        // The trigonometric values for each delta theta.
+        std::vector<TrigonometricValues> angular_trig_values_;
 
-  // The trigonometric values for each delta phi. In the case where delta theta is equal to delta phi,
-  // this is left uninitialized and angular_trig_values_ is used.
-  std::vector<TrigonometricValues> azimuthal_trig_values_;
-};
+        // The trigonometric values for each delta phi. In the case where delta theta is equal to delta phi,
+        // this is left uninitialized and angular_trig_values_ is used.
+        std::vector<TrigonometricValues> azimuthal_trig_values_;
+    };
 
 } // namespace svr
 

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 namespace svr {
-    constexpr double tau = 2 * M_PI;
+    constexpr double TAU = 2 * M_PI;
 
 // Represents a line segment. This is used to represent the points of intersections between
 // the lines corresponding to voxel boundaries and a given radial voxel.
@@ -41,8 +41,8 @@ struct SphericalVoxelGrid {
 	  sphere_center_(sphere_center),
 	  sphere_max_radius_(sphere_max_radius),
 	  delta_radius_(sphere_max_radius / num_radial_voxels),
-	  delta_theta_(tau / num_angular_voxels),
-	  delta_phi_(tau / num_azimuthal_voxels),
+	  delta_theta_(TAU / num_angular_voxels),
+	  delta_phi_(TAU / num_azimuthal_voxels),
 	  inv_delta_radius_(1.0 / delta_radius_) {
 
 	  P_max_angular_.resize(num_angular_voxels + 1);

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -128,7 +128,7 @@ namespace svr {
         angularTrigValues() const noexcept { return angular_trig_values_; }
 
         inline const std::vector<TrigonometricValues> &
-                azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
+        azimuthalTrigValues() const noexcept { return azimuthal_trig_values_; }
 
     private:
         // The minimum bound vector of the voxel grid.

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -43,8 +43,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(3.0, 3.0, 3.0);
         const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
@@ -64,8 +63,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
@@ -88,9 +86,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
         const FreeVec3 ray_direction(1.0, 1.5, 1.0);
         const Ray ray(ray_origin, ray_direction);
@@ -113,8 +110,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
         const FreeVec3 ray_direction(1.0, 0.0, 0.0);
@@ -137,8 +133,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, -15.0, 0.0);
         const FreeVec3 ray_direction(0.0, 1.0, 0.0);
@@ -161,8 +156,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, 0.0, -15.0);
         const FreeVec3 ray_direction(0.0, 0.0, 1.0);
@@ -185,8 +179,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
         const FreeVec3 ray_direction(1.0, 1.0, 0.0);
@@ -209,8 +202,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
         const FreeVec3 ray_direction(1.0, 0.0, 1.0);
@@ -233,8 +225,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections,
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, -15.0, -15.0);
         const FreeVec3 ray_direction(0.0, 1.0, 1.0);
@@ -257,9 +248,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(13.0, -15.0, -15.0);
         const FreeVec3 ray_direction(-1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
@@ -281,9 +271,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
         const FreeVec3 ray_direction(1.0, -1.2, 1.3);
         const Ray ray(ray_origin, ray_direction);
@@ -305,9 +294,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
         const FreeVec3 ray_direction(1.4, 2.0, -1.3);
         const Ray ray(ray_origin, ray_direction);
@@ -329,9 +317,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(15.0, 12.0, 15.0);
         const FreeVec3 ray_direction(-1.4, -2.0, -1.3);
         const Ray ray(ray_origin, ray_direction);
@@ -353,9 +340,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 3;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.3);
         const Ray ray(ray_origin, ray_direction);
@@ -377,9 +363,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 3;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
@@ -401,9 +386,8 @@ namespace {
         const std::size_t num_radial_sections = 40;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
@@ -438,9 +422,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 40;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
@@ -462,9 +445,8 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 40;
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                           num_angular_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);


### PR DESCRIPTION
In both angular and azimuthal hit, we were calculating
```p, p_end, v``` separately. These represent (respectively) the ray segment at time t, the ray segment at time t_end, and the free vector represented by ```p_end - p```. I've replaced:
 ```p``` ->```P1```
```p_end``` -> ```P2```
```v``` -> ```ray_segment```

```P2``` never changes since ```t_end``` never changes.
We can calculate ```P1, ray_segment``` once with each iteration, and pass it in each plane hit function respectively. This means we update ```P1, ray_segment``` once per iteration (using ```updateRaySegmentPoints()``` rather than twice per iteration, and ```P2``` once per sphericalVoxelTraversal call. 

Next, I've added a collinear_times array to get rid of two branch predictions per traversal and reduce a calculation to once per sphericalVoxelTraversal call rather than once per collinear hit.


In other news,
- Some of the spacing in my file was wonky. This has been fixed.
- Avoid copies when returning a Vec3 or similar by returning a const reference.
