### PR TITLE
Remove need of std::vector in radialHit(), only use ABS_EPSILON to determine FP equality.

### DIFF
--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -18,10 +18,7 @@ struct Ray final {
             : origin_(origin), direction_(direction), unit_direction_(direction),
               inverse_direction_(FreeVec3(1.0 / direction.x(), 1.0 / direction.y(), 1.0 / direction.z())),
               NZD_index_(std::abs(direction.x()) > 0.0 ? X_DIRECTION :
-                         std::abs(direction.y()) > 0.0 ? Y_DIRECTION : Z_DIRECTION),
-              NZD_origin_(origin[NZD_index_]),
-              NZD_inverse_direction_(inverse_direction_[NZD_index_]),
-              NZD_unit_direction_(unit_direction_[NZD_index_]) {}
+                         std::abs(direction.y()) > 0.0 ? Y_DIRECTION : Z_DIRECTION) {}
 
     // Represents the function p(t) = origin + t * direction,
     // where p is a 3-dimensional position, and t is a scalar.
@@ -37,12 +34,12 @@ struct Ray final {
     // Since Point p = ray.origin() + ray.direction() * (v +/- discriminant),
     // We can simply provide the difference or addition of v and the discriminant.
     inline double timeOfIntersectionAt(double discriminant_v) const noexcept {
-      return this->NZD_unit_direction_ * discriminant_v * this->NZD_inverse_direction_;
+      return this->unit_direction_[NZD_index_] * discriminant_v * this->inverse_direction_[NZD_index_];
     }
 
     // Similar to above implementation, but uses a given vector p.
     inline double timeOfIntersectionAt(const Vec3 &p) const noexcept {
-      return (p[NZD_index_] - this->NZD_origin_) * this->NZD_inverse_direction_;
+      return (p[NZD_index_] - this->origin_[NZD_index_]) * this->inverse_direction_[NZD_index_];
     }
 
     inline const BoundVec3 &origin() const noexcept { return this->origin_; }
@@ -52,6 +49,8 @@ struct Ray final {
     inline const FreeVec3 &invDirection() const noexcept { return this->inverse_direction_; }
 
     inline const UnitVec3 &unitDirection() const noexcept { return this->unit_direction_; }
+
+    inline NonZeroDirectionIndex NonZeroDirectionIndex() const noexcept { return this->NZD_index_; }
 
 private:
     // The origin of the ray.
@@ -67,10 +66,7 @@ private:
     const FreeVec3 inverse_direction_;
 
     // Index of a non-zero direction.
-    const NonZeroDirectionIndex NZD_index_;
-
-    // The non-zero direction values to avoid using the [] operator with each function call.
-    const double NZD_origin_, NZD_inverse_direction_, NZD_unit_direction_;
+    const enum NonZeroDirectionIndex NZD_index_;
 };
 
 #endif //SPHERICAL_VOLUME_RENDERING_RAY_H

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -4,7 +4,7 @@
 #include "vec3.h"
 
 // The indices for Vec3. For example, Vec3[0] returns the x-direction.
-enum NonZeroDirectionIndex {
+enum DirectionIndex {
   X_DIRECTION = 0,
   Y_DIRECTION = 1,
   Z_DIRECTION = 2
@@ -50,7 +50,7 @@ struct Ray final {
 
     inline const UnitVec3 &unitDirection() const noexcept { return this->unit_direction_; }
 
-    inline NonZeroDirectionIndex NonZeroDirectionIndex() const noexcept { return this->NZD_index_; }
+    inline DirectionIndex NonZeroDirectionIndex() const noexcept { return this->NZD_index_; }
 
 private:
     // The origin of the ray.
@@ -66,7 +66,7 @@ private:
     const FreeVec3 inverse_direction_;
 
     // Index of a non-zero direction.
-    const enum NonZeroDirectionIndex NZD_index_;
+    const enum DirectionIndex NZD_index_;
 };
 
 #endif //SPHERICAL_VOLUME_RENDERING_RAY_H

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -3,13 +3,6 @@
 
 #include "vec3.h"
 
-// The indices for Vec3. For example, Vec3[0] returns the x-direction.
-enum DirectionIndex {
-  X_DIRECTION = 0,
-  Y_DIRECTION = 1,
-  Z_DIRECTION = 2
-};
-
 // Encapsulates the functionality of a ray. This consists of two components, the origin of the ray, and the
 // direction of the ray. To avoid checking for a non-zero direction upon each function call, these parameters are
 // initialized upon construction.

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -14,7 +14,7 @@ enum NonZeroDirectionIndex {
 // direction of the ray. To avoid checking for a non-zero direction upon each function call, these parameters are
 // initialized upon construction.
 struct Ray final {
-    Ray(const BoundVec3 &origin, const FreeVec3 &direction)
+    inline Ray(const BoundVec3 &origin, const FreeVec3 &direction)
             : origin_(origin), direction_(direction), unit_direction_(direction),
               inverse_direction_(FreeVec3(1.0 / direction.x(), 1.0 / direction.y(), 1.0 / direction.z())),
               NZD_index_(std::abs(direction.x()) > 0.0 ? X_DIRECTION :

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -171,7 +171,7 @@ namespace svr {
             const double d1d2 = (px_p1_diff * px_p1_diff) + (py_p1_diff * py_p1_diff) +
                                 (n_px_p1_diff * n_px_p1_diff) + (n_py_p1_diff * n_py_p1_diff);
             const double d3 = (px_diff * px_diff) + (py_diff * py_diff);
-            if (lessThan(d1d2, d3) || isEqual(d1d2, d3)) { return i; }
+            if (d1d2 < d3 || isEqual(d1d2, d3)) { return i; }
             ++i;
         }
         return -1;
@@ -228,7 +228,7 @@ namespace svr {
         const bool is_radial_transition = isEqual(r_new, current_radius);
         const bool is_not_tangential_hit = !(isEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
         return {.tMaxR=*intersection_time,
-                .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
+                .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&
                              !is_radial_transition && lessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds=lessThan(t, *intersection_time) && lessThan(*intersection_time, t_end)

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -109,6 +109,15 @@ namespace svr {
         inline void updateRaySegmentAtTime(double t) noexcept {
             P1 = ray->pointAtParameter(t);
             ray_segment = P2 - P1;
+
+        }
+
+        // Calculates the updated ray segment intersection point given an intersect parameter.
+        // More information on this use case can be found at:
+        // http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
+        inline double raySegmentIntersectionTimeAt(double intersect_param) const noexcept {
+            const auto idx = ray->NonZeroDirectionIndex();
+            return (P1[idx] + ray_segment[idx] * intersect_param - ray->origin()[idx]) * ray->invDirection()[idx];
         }
 
         // The begin point of the ray segment.
@@ -261,9 +270,7 @@ namespace svr {
             b = perp_uw_min * inv_perp_uv_min;
             if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
                 is_intersect_min = true;
-                t_min = ray.timeOfIntersectionAt(Vec3(rs_data.P1.x() + rs_data.ray_segment.x() * b,
-                                                      rs_data.P1.y() + rs_data.ray_segment.y() * b,
-                                                      rs_data.P1.z() + rs_data.ray_segment.z() * b));
+                t_min = rs_data.raySegmentIntersectionTimeAt(b);
             }
         }
         double t_max = collinear_times[is_collinear_max];
@@ -274,9 +281,7 @@ namespace svr {
             b = perp_uw_max * inv_perp_uv_max;
             if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
                 is_intersect_max = true;
-                t_max = ray.timeOfIntersectionAt(Vec3(rs_data.P1.x() + rs_data.ray_segment.x() * b,
-                                                      rs_data.P1.y() + rs_data.ray_segment.y() * b,
-                                                      rs_data.P1.z() + rs_data.ray_segment.z() * b));
+                t_max = rs_data.raySegmentIntersectionTimeAt(b);
             }
         }
         GenHitParameters params;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -80,10 +80,10 @@ namespace svr {
 
     // The necessary information to calculate a radial hit. ray_sphere_vector_dot and v are calculated in the
     // initialization phase, so unnecessary to re-calculate again for radial hit. intersection_times
-    // is used to determine the type of radial hit. Upon initialization, the previous transition flag is set to false.
+    // is used to determine the type of radial hit.
     struct RadialHitData {
         inline RadialHitData(double t_v, double t_ray_sphere_vector_dot) :
-        v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot), previous_transition_flag(false) {}
+        v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot) {}
 
         // Pre-calculated data to be used when calculating a radial hit.
         double v, ray_sphere_vector_dot;
@@ -93,7 +93,7 @@ namespace svr {
 
         // The current state of the previous_transition_flag. This is saved here so that it can be passed
         // into the radial hit function with each traversal.
-        bool previous_transition_flag;
+        bool transition_flag;
     };
 
     // Pre-calculated information for the generalized plane hit function, which generalizes azimuthal and angular
@@ -187,7 +187,7 @@ namespace svr {
         const double current_radius = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
         double r_a = std::max(current_radius - grid.deltaRadius(), grid.deltaRadius());
         double r_b;
-        if (!rdata.previous_transition_flag) {
+        if (!rdata.transition_flag) {
             // To find the next radius, we need to check the previous_transition_flag:
             // In the case that the ray has sequential hits with equal radii, e.g.
             // the innermost radial disc, this ensures that the proper radii are being checked.
@@ -568,7 +568,7 @@ namespace svr {
 
         while (true) {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
-            radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
+            radial_hit_data.transition_flag = radial_params.previous_transition_flag;
             ray_segment.updateRaySegmentAtTime(t);
             const auto angular_params = angularHit(ray, grid, ray_segment, collinear_times,
                                                    current_voxel_ID_theta, t, t_end);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -83,10 +83,10 @@ namespace svr {
     // is used to determine the type of radial hit.
     struct RadialHitData {
         inline RadialHitData(double t_v, double t_ray_sphere_vector_dot) :
-        v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot) {}
+                ray_sphere_vector_dot(t_ray_sphere_vector_dot), v(t_v) {}
 
         // Pre-calculated data to be used when calculating a radial hit.
-        double v, ray_sphere_vector_dot;
+        double ray_sphere_vector_dot, v;
 
         // Pre-initialized structure to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -235,7 +235,7 @@ namespace svr {
         }
         const double r_new = (ray.pointAtParameter(*intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
-        const bool is_not_tangential_hit = found_time_greater_than_t && !(isKnEqual(rdata.intersection_times[0],
+        const bool is_not_tangential_hit = !(found_time_greater_than_t && isKnEqual(rdata.intersection_times[0],
                                                                                     rdata.intersection_times[1]));
         return {.tMaxR=*intersection_time,
                 .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -88,7 +88,7 @@ namespace svr {
         // Pre-calculated data to be used when calculating a radial hit.
         double v, ray_sphere_vector_dot;
 
-        // Pre-initialized structures to be used when calculating a radial hit.
+        // Pre-initialized structure to be used when calculating a radial hit.
         std::array<double, 4> intersection_times;
 
         // The current state of the previous_transition_flag. This is saved here so that it can be passed

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -109,7 +109,6 @@ namespace svr {
         inline void updateRaySegmentAtTime(double t) noexcept {
             P1 = ray->pointAtParameter(t);
             ray_segment = P2 - P1;
-
         }
 
         // Calculates the updated ray segment intersection point given an intersect parameter.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -226,8 +226,7 @@ namespace svr {
                                                     rdata.intersection_times.cend(),
                                                     [t](double i)->double{ return i > t;});
 
-        const bool found_time_greater_than_t = intersection_time != rdata.intersection_times.cend();
-        if (!found_time_greater_than_t) {
+        if (intersection_time == rdata.intersection_times.cend()) {
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
                     .previous_transition_flag=false,
@@ -235,8 +234,7 @@ namespace svr {
         }
         const double r_new = (ray.pointAtParameter(*intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
-        const bool is_not_tangential_hit = !(found_time_greater_than_t && isKnEqual(rdata.intersection_times[0],
-                                                                                    rdata.intersection_times[1]));
+        const bool is_not_tangential_hit = !(isKnEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
         return {.tMaxR=*intersection_time,
                 .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
                              !is_radial_transition && KnLessThan(r_new, current_radius))],

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -13,6 +13,7 @@ namespace svr {
 
     // Epsilons used for floating point comparisons in Knuth's algorithm.
     constexpr double ABS_EPSILON = 1e-12;
+    constexpr double REL_EPSILON = 1e-8;
 
     // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
     enum VoxelIntersectionType {
@@ -132,14 +133,20 @@ namespace svr {
     //        Donald. E. Knuth, 1998, Addison-Wesley Longman, Inc., ISBN 0-201-89684-2, Addison-Wesley Professional;
     //        3rd edition. (The relevant equations are in §4.2.2, Eq. 36 and 37.)
     inline bool isKnEqual(double a, double b) noexcept {
-        return std::abs(a - b) <= ABS_EPSILON;
+        const double diff = std::abs(a - b);
+        if (diff <= ABS_EPSILON) { return true; }
+        return diff <= std::max(std::abs(a), std::abs(b)) * REL_EPSILON;
     }
 
     // Overloaded version that checks for Knuth equality with vector cartesian coordinates.
     inline bool isKnEqual(const Vec3 &a, const Vec3 &b) noexcept {
-        return std::abs(a.x() - b.x()) <= ABS_EPSILON &&
-               std::abs(a.y() - b.y()) <= ABS_EPSILON &&
-               std::abs(a.z() - b.z()) <= ABS_EPSILON;
+        const double diff_x = std::abs(a.x() - b.x());
+        const double diff_y = std::abs(a.y() - b.y());
+        const double diff_z = std::abs(a.z() - b.z());
+        if (diff_x <= ABS_EPSILON && diff_y <= ABS_EPSILON && diff_z <= ABS_EPSILON) { return true; }
+        return diff_x <= std::max(std::abs(a.x()), std::abs(b.x())) * REL_EPSILON &&
+               diff_y <= std::max(std::abs(a.y()), std::abs(b.y())) * REL_EPSILON &&
+               diff_z <= std::max(std::abs(a.z()), std::abs(b.z())) * REL_EPSILON;
     }
 
     // Uses the Knuth algorithm in KnEqual() to ensure that a is strictly less than b.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -226,8 +226,8 @@ namespace svr {
                                                     rdata.intersection_times.cend(),
                                                     [t](double i)->double{ return i > t;});
 
-        if (intersection_time == rdata.intersection_times.cend()) {
-            // No intersection.
+        const bool found_time_greater_than_t = intersection_time != rdata.intersection_times.cend();
+        if (!found_time_greater_than_t) {
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
                     .previous_transition_flag=false,
@@ -235,7 +235,8 @@ namespace svr {
         }
         const double r_new = (ray.pointAtParameter(*intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isKnEqual(r_new, current_radius);
-        const bool is_not_tangential_hit = !(isKnEqual(rdata.intersection_times[0], rdata.intersection_times[1]));
+        const bool is_not_tangential_hit = found_time_greater_than_t && !(isKnEqual(rdata.intersection_times[0],
+                                                                                    rdata.intersection_times[1]));
         return {.tMaxR=*intersection_time,
                 .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&          // { 0, -1, 1 }
                              !is_radial_transition && KnLessThan(r_new, current_radius))],

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <numeric>
 #include <cmath>
-#include <limits>
 #include <array>
 
 // The indices for Vec3. For example, Vec3[0] returns the x-direction.

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -7,6 +7,13 @@
 #include <limits>
 #include <array>
 
+// The indices for Vec3. For example, Vec3[0] returns the x-direction.
+enum DirectionIndex {
+    X_DIRECTION = 0,
+    Y_DIRECTION = 1,
+    Z_DIRECTION = 2
+};
+
 // Represents a Euclidean vector in 3-dimensional space.
 // Assumes vectors take the form of:
 //      [x]

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -5,6 +5,7 @@
 #include <numeric>
 #include <cmath>
 #include <limits>
+#include <array>
 
 // Represents a Euclidean vector in 3-dimensional space.
 // Assumes vectors take the form of:
@@ -13,44 +14,34 @@
 //      [z]
 struct Vec3 {
 public:
-    constexpr inline Vec3(const double x, const double y, const double z) : x_(x), y_(y), z_(z) {}
+    constexpr inline Vec3(const double x, const double y, const double z) : e_{x,y,z} {}
 
-    constexpr inline double x() const noexcept { return this->x_; }
+    constexpr inline double x() const noexcept { return this->e_[0]; }
 
-    constexpr inline double y() const noexcept { return this->y_; }
+    constexpr inline double y() const noexcept { return this->e_[1]; }
 
-    constexpr inline double z() const noexcept { return this->z_; }
+    constexpr inline double z() const noexcept { return this->e_[2]; }
 
-    inline double &x() noexcept { return this->x_; }
+    inline double &x() noexcept { return this->e_[0]; }
 
-    inline double &y() noexcept { return this->y_; }
+    inline double &y() noexcept { return this->e_[1]; }
 
-    inline double &z() noexcept { return this->z_; }
+    inline double &z() noexcept { return this->e_[2]; }
 
     inline double length() const noexcept {
-        return std::sqrt(this->x_ * this->x_ + this->y_ * this->y_ + this->z_ * this->z_);
+        return std::sqrt(this->e_[0] * this->e_[0]  + this->e_[1]  * this->e_[1]  + this->e_[2]  * this->e_[2]);
     }
 
     constexpr inline double squared_length() const noexcept {
-        return x_ * x_ + y_ * y_ + z_ * z_;
+        return e_[0] * e_[0] + e_[1] * e_[1] + e_[2] * e_[2];
     }
 
     inline double operator[](const std::size_t index) const noexcept {
-        switch(index) {
-          case 0: return this->x_;
-          case 1: return this->y_;
-          case 2: return this->z_;
-        }
-        return std::numeric_limits<double>::quiet_NaN();
+        return e_[index];
   }
 
 private:
-    // Represents the x-dimension value of the vector.
-    double x_;
-    // Represents the y-dimension value of the vector.
-    double y_;
-    // Represents the z-dimension value of the vector.
-    double z_;
+    std::array<double, 3> e_;
 };
 
 // A 3-dimensional free vector, which has no initial point. It has two main criteria:
@@ -175,12 +166,7 @@ struct UnitVec3 {
     inline const FreeVec3 &to_free() const noexcept { return inner_; }
 
     inline double operator[](const std::size_t index) const noexcept {
-        switch(index) {
-           case 0: return this->x();
-           case 1: return this->y();
-           case 2: return this->z();
-        }
-        return std::numeric_limits<double>::quiet_NaN();
+        return this->to_free()[index];
     }
 
 private:


### PR DESCRIPTION
So using std::vector in radialHit() to calculate multiple values for times_gt_t was causing a bit of a slowdown. Calling clear() is expensive, and similar for iterating through. 

I saw that we only used times_gt_t[0] ever to calculate the intersection_time, or tMaxR.
Then, it is sufficient to find the first time greater than t.

The one issue would be in the tangential hit case, where intersection_times[0] and intersection_times[1] are equal, but there are not two times greater than t.

In other words, ```ray.timeOfIntersectionAt(v - d_a) == ray.timeOfIntersectionAt(v + d_a)```, one of them is greater than t, but the other isn't. This contradicts itself; therefore, we can lessen the logic a bit.

In other news, 
- Remove the use of a REL_EPSILON. Now, all FP equality is determined by an ABS_EPSILON.
- I've used the NonZeroDirectionIndex() in the ray segment portion. This ensures we don't need to calculate P1 + ray_segment * b for x,y,z with each GeneralizedPlaneHit() call.
- Vec3 is now backed by a std::array. This means the Vec3[] operator is random-access.