### PR TITLE
Pre-initialize deltaRadii calculations.

### DIFF
--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -79,8 +79,6 @@ namespace svr {
 
     // A lot of calculations are conducted in the initialization phase already. To mitigate these from occurring again,
     // This structure allows the calculations to be saved for use during radialHit().
-    // transition_flag_ is used with each iteration of the traversal to determine if we've made a transition
-    // in sign for radial steps.
     struct RadialHitData {
     public:
         inline RadialHitData(double v, double rsvd_minus_v_squared) :
@@ -93,12 +91,13 @@ namespace svr {
         inline bool transitionFlag() const noexcept { return transition_flag_; }
 
         inline void updateTransitionFlag(bool b) noexcept { transition_flag_ = b; }
+
     private:
         // Pre-calculated data to be used when calculating a radial hit.
         const double v_, rsvd_minus_v_squared_;
 
-        // The current state of the previous_transition_flag. This is saved here so that it can be passed
-        // into the radial hit function with each traversal.
+        // The current state of the previous_transition_flag. It marks if we've made a transition
+        // in sign for radial steps, i.e. + => - or - => +.
         bool transition_flag_;
     };
 
@@ -127,8 +126,11 @@ namespace svr {
         }
 
         inline const BoundVec3 &P1() const noexcept { return P1_; }
+
         inline const BoundVec3 &P2() const noexcept { return P2_; }
+
         inline const FreeVec3 &raySegment() const noexcept { return ray_segment_; }
+
     private:
         // The associated ray for which the segment (P1, P2) refers to.
         const Ray *ray_;
@@ -513,7 +515,7 @@ namespace svr {
         initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius);
 
         double a, b, c;
-        const bool ray_origin_is_outside_grid = current_voxel_ID_r == 1;
+        const bool ray_origin_is_outside_grid = entry_radius == grid.sphereMaxRadius();
         if (isEqual(ray.origin(), grid.sphereCenter())) {
             // If the ray starts at the sphere's center, we need to perturb slightly along
             // the path to determine the correct angular and azimuthal voxel.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -290,15 +290,15 @@ namespace svr {
             }
         }
         GenHitParameters params;
-        if (is_intersect_max && !is_intersect_min && !is_collinear_min && lessThan(t_max, t_end) &&
-            lessThan(t, t_max)) {
+        const bool t_max_within_bounds = lessThan(t, t_max) && lessThan(t_max, t_end);
+        if (is_intersect_max && !is_intersect_min && !is_collinear_min &&  t_max_within_bounds) {
             params.tStep = 1;
             params.tMax = t_max;
             params.within_bounds = true;
             return params;
         }
-        if (is_intersect_min && !is_intersect_max && !is_collinear_max && lessThan(t_min, t_end) &&
-            lessThan(t, t_min)) {
+        const bool t_min_within_bounds = lessThan(t, t_min) && lessThan(t_min, t_end);
+        if (is_intersect_min && !is_intersect_max && !is_collinear_max && t_min_within_bounds) {
             params.tStep = -1;
             params.tMax = t_min;
             params.within_bounds = true;
@@ -307,7 +307,6 @@ namespace svr {
         if ((is_intersect_min && is_intersect_max) ||
             (is_intersect_min && is_collinear_max) ||
             (is_intersect_max && is_collinear_min)) {
-            const bool t_min_within_bounds = lessThan(t, t_min) && lessThan(t_min, t_end);
             if (t_min_within_bounds && isEqual(t_min, t_max)) {
                 params.tMax = t_max;
                 const double perturbed_t = 0.1;
@@ -329,7 +328,6 @@ namespace svr {
                 params.within_bounds = true;
                 return params;
             }
-            const bool t_max_within_bounds = lessThan(t, t_max) && lessThan(t_max, t_end);
             if (t_max_within_bounds && (lessThan(t_max, t_min) || isEqual(t, t_min))) {
                 params.tStep = 1;
                 params.tMax = t_max;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -79,16 +79,14 @@ namespace svr {
 
     // A lot of calculations are conducted in the initialization phase already. To mitigate these from occurring again,
     // This structure allows the calculations to be saved for use during radialHit().
-    // transition_flag_ is used with each iteration of the traversal.
+    // transition_flag_ is used with each iteration of the traversal to determine if we've made a transition
+    // in sign for radial steps.
     struct RadialHitData {
     public:
-        inline RadialHitData(double v, double rsvd, double rsvd_minus_v_squared) :
-                ray_sphere_vector_dot_product_(rsvd), v_(v),
-                rsvd_minus_v_squared_(rsvd_minus_v_squared){}
+        inline RadialHitData(double v, double rsvd_minus_v_squared) :
+        v_(v), rsvd_minus_v_squared_(rsvd_minus_v_squared) {}
 
         inline double v() const noexcept { return v_; }
-
-        inline double rsvd() const noexcept { return ray_sphere_vector_dot_product_; }
 
         inline double rsvdMinusVSquared() const noexcept { return rsvd_minus_v_squared_;}
 
@@ -97,7 +95,7 @@ namespace svr {
         inline void updateTransitionFlag(bool b) noexcept { transition_flag_ = b; }
     private:
         // Pre-calculated data to be used when calculating a radial hit.
-        const double ray_sphere_vector_dot_product_, v_, rsvd_minus_v_squared_;
+        const double v_, rsvd_minus_v_squared_;
 
         // The current state of the previous_transition_flag. This is saved here so that it can be passed
         // into the radial hit function with each traversal.
@@ -578,7 +576,7 @@ namespace svr {
         // Initialize the time in case of collinear min or collinear max for generalized plane hits.
         std::array<double, 2> collinear_times = {INVALID_TIME, ray.timeOfIntersectionAt(grid.sphereCenter())};
 
-        RadialHitData radial_hit_data(v, rsvd, rsvd_minus_v_squared);
+        RadialHitData radial_hit_data(v, rsvd_minus_v_squared);
         RaySegment ray_segment(&ray, t_end);
 
         while (true) {

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -199,7 +199,7 @@ namespace svr {
     RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid, RadialHitData &rh_data,
                                   int current_voxel_ID_r, double t, double t_end) noexcept {
         const double current_radius = grid.deltaRadii(current_voxel_ID_r);
-        const double next_radius = grid.deltaRadii(current_voxel_ID_r + 1);
+        const double next_radius = current_radius - grid.deltaRadius();
         double r_a = std::max(next_radius, grid.deltaRadius());
 
         // To find the next radius, we need to check the previous_transition_flag:

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -487,7 +487,8 @@ namespace svr {
             --idx;
             return rsvd <= dR * dR;
         });
-        const double entry_radius = (it != grid.deltaRadii().crend()) ? *it : grid.sphereMaxRadius();
+        const bool ray_origin_is_outside_grid = (it == grid.deltaRadii().crend());
+        const double entry_radius = !ray_origin_is_outside_grid ? *it : grid.sphereMaxRadius();
 
         // Find the intersection times for the ray and the radial shell containing the parameter point at t_begin.
         // This will determine if the ray intersects the sphere.
@@ -515,7 +516,6 @@ namespace svr {
         initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius);
 
         double a, b, c;
-        const bool ray_origin_is_outside_grid = entry_radius == grid.sphereMaxRadius();
         if (isEqual(ray.origin(), grid.sphereCenter())) {
             // If the ray starts at the sphere's center, we need to perturb slightly along
             // the path to determine the correct angular and azimuthal voxel.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -576,7 +576,7 @@ namespace svr {
         t_end = std::min(t_grid_exit, t_end);
 
         // Initialize the time in case of collinear min or collinear max for generalized plane hits.
-        std::array<double, 2> collinear_times = {INVALID_TIME, ray.timeOfIntersectionAt(grid.sphereCenter())};
+        const std::array<double, 2> collinear_times = {INVALID_TIME, ray.timeOfIntersectionAt(grid.sphereCenter())};
 
         RadialHitData radial_hit_data(v, rsvd_minus_v_squared);
         RaySegment ray_segment(&ray, t_end);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -198,9 +198,8 @@ namespace svr {
     // http://cas.xav.free.fr/Graphics%20Gems%204%20-%20Paul%20S.%20Heckbert.pdf
     RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid, RadialHitData &rh_data,
                                   int current_voxel_ID_r, double t, double t_end) noexcept {
-        const std::size_t idx = current_voxel_ID_r;
-        const double current_radius = grid.deltaRadii(idx);
-        const double next_radius = grid.deltaRadii(idx + 1);
+        const double current_radius = grid.deltaRadii(current_voxel_ID_r);
+        const double next_radius = grid.deltaRadii(current_voxel_ID_r + 1);
         double r_a = std::max(next_radius, grid.deltaRadius());
 
         // To find the next radius, we need to check the previous_transition_flag:

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -42,11 +42,10 @@ namespace svr {
                 sphere_max_radius_(sphere_max_radius),
                 delta_radius_(sphere_max_radius / num_radial_voxels),
                 delta_theta_(TAU / num_angular_voxels),
-                delta_phi_(TAU / num_azimuthal_voxels),
-                inv_delta_radius_(1.0 / delta_radius_) {
+                delta_phi_(TAU / num_azimuthal_voxels) {
 
             delta_radii_.resize(num_radial_voxels + 1);
-            double current_delta_radius = delta_radius_ * (num_radial_voxels + 1);
+            double current_delta_radius = delta_radius_ * (num_radial_voxels + 1.0);
             std::generate(delta_radii_.begin(), delta_radii_.end(),
                           [&]() -> double {
                               const double old_delta_radius = current_delta_radius;
@@ -122,9 +121,9 @@ namespace svr {
 
         inline double deltaRadius() const noexcept { return this->delta_radius_; }
 
-        inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
-
         inline double deltaRadii(std::size_t i) const noexcept { return this->delta_radii_[i]; }
+
+        inline const std::vector<double> &deltaRadii() const noexcept { return this->delta_radii_; }
 
         inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
@@ -161,9 +160,6 @@ namespace svr {
 
         // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
         const double delta_theta_, delta_phi_;
-
-        // Inverse of the above delta values.
-        const double inv_delta_radius_;
 
         // The delta radii ranging from 0...num_radial_voxels.
         std::vector<double> delta_radii_;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -45,9 +45,17 @@ namespace svr {
                 delta_phi_(TAU / num_azimuthal_voxels),
                 inv_delta_radius_(1.0 / delta_radius_) {
 
+            delta_radii_.resize(num_radial_voxels + 1);
+            double current_delta_radius = delta_radius_ * (num_radial_voxels + 1);
+            std::generate(delta_radii_.begin(), delta_radii_.end(),
+                          [&]() -> double {
+                              const double old_delta_radius = current_delta_radius;
+                              current_delta_radius -= delta_radius_;
+                              return old_delta_radius;
+                          });
+
             P_max_angular_.resize(num_angular_voxels + 1);
             P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
-
             if (num_angular_voxels == num_azimuthal_voxels) {
                 double radians = 0.0;
                 angular_trig_values_.resize(num_angular_voxels + 1);
@@ -116,6 +124,8 @@ namespace svr {
 
         inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
 
+        inline double deltaRadii(std::size_t i) const noexcept { return this->delta_radii_[i]; }
+
         inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
         inline const std::vector<LineSegment> &pMaxAngular() const noexcept { return this->P_max_angular_; }
@@ -154,6 +164,9 @@ namespace svr {
 
         // Inverse of the above delta values.
         const double inv_delta_radius_;
+
+        // The delta radii ranging from 0...num_radial_voxels.
+        std::vector<double> delta_radii_;
 
         // The maximum radius line segments for angular voxels.
         std::vector<LineSegment> P_max_angular_;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -44,8 +44,8 @@ namespace svr {
                 delta_theta_(TAU / num_angular_voxels),
                 delta_phi_(TAU / num_azimuthal_voxels) {
 
-            delta_radii_.resize(num_radial_voxels + 1);
-            double current_delta_radius = delta_radius_ * (num_radial_voxels + 1.0);
+            delta_radii_.resize(num_radial_voxels);
+            double current_delta_radius = delta_radius_ * num_radial_voxels;
             std::generate(delta_radii_.begin(), delta_radii_.end(),
                           [&]() -> double {
                               const double old_delta_radius = current_delta_radius;

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -21,6 +21,7 @@ enum DirectionIndex {
 struct Vec3 {
 public:
     constexpr inline Vec3(const double x, const double y, const double z) : e_{x,y,z} {}
+
     constexpr inline Vec3() : e_{0.0, 0.0, 0.0} {}
 
     constexpr inline double x() const noexcept { return this->e_[0]; }

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -21,6 +21,7 @@ enum DirectionIndex {
 struct Vec3 {
 public:
     constexpr inline Vec3(const double x, const double y, const double z) : e_{x,y,z} {}
+    constexpr inline Vec3() : e_{0.0, 0.0, 0.0} {}
 
     constexpr inline double x() const noexcept { return this->e_[0]; }
 
@@ -58,6 +59,8 @@ private:
 struct FreeVec3 : Vec3 {
 
     constexpr inline explicit FreeVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
+
+    constexpr inline FreeVec3() : Vec3() {}
 
     constexpr inline explicit FreeVec3(double x, double y, double z) : Vec3(x, y, z) {}
 
@@ -120,6 +123,8 @@ inline FreeVec3 operator/(FreeVec3 v, const double scalar) noexcept {
 // in space, relative to some frame of reference.
 struct BoundVec3 : Vec3 {
     constexpr inline explicit BoundVec3(const Vec3 &vec3) : Vec3(vec3.x(), vec3.y(), vec3.z()) {}
+
+    constexpr inline BoundVec3() : Vec3() {}
 
     constexpr inline explicit BoundVec3(double x, double y, double z) : Vec3(x, y, z) {}
 


### PR DESCRIPTION
- Pre-initializes delta radii calculations in the sphericalVoxelGrid. These can be accessed by index. This greatly reduces calculations in the initialization phase.
- Updates generalizedPlaneHit() to remove two knLessThan() duplications.
- Other clean up.