### PR TITLE
Reduce radialHit() calculations.

### DIFF
--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -299,15 +299,22 @@ namespace svr {
                 t_max = RS.raySegmentIntersectionTimeAt(b);
             }
         }
-        GenHitParameters params;
         const bool t_max_within_bounds = lessThan(t, t_max) && lessThan(t_max, t_end);
-        if (is_intersect_max && !is_intersect_min && !is_collinear_min &&  t_max_within_bounds) {
+        const bool t_min_within_bounds = lessThan(t, t_min) && lessThan(t_min, t_end);
+        if (!t_max_within_bounds && !t_min_within_bounds) {
+            return {.tStep = 0,
+                    .tMax = std::numeric_limits<double>::max(),
+                    .within_bounds = false
+            };
+        }
+
+        GenHitParameters params;
+        if (is_intersect_max && !is_intersect_min && !is_collinear_min && t_max_within_bounds) {
             params.tStep = 1;
             params.tMax = t_max;
             params.within_bounds = true;
             return params;
         }
-        const bool t_min_within_bounds = lessThan(t, t_min) && lessThan(t_min, t_end);
         if (is_intersect_min && !is_intersect_max && !is_collinear_max && t_min_within_bounds) {
             params.tStep = -1;
             params.tMax = t_min;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -240,10 +240,8 @@ namespace svr {
                                                     [t](double i)->double{ return i > t;});
         const double intersection_time = *intersection_time_it;
 
-        bool within_time_bounds;
         if (intersection_time_it == intersection_times.cend() ||
-            !( within_time_bounds = lessThan(t, intersection_time) && lessThan(intersection_time, t_end) )
-            ) {
+            !(lessThan(t, intersection_time) && lessThan(intersection_time, t_end))) {
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
                     .previous_transition_flag=false,
@@ -256,7 +254,7 @@ namespace svr {
                 .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&
                              !is_radial_transition && lessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
-                .within_bounds=within_time_bounds
+                .within_bounds=true
         };
     }
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -357,9 +357,9 @@ namespace svr {
 
     // Determines whether an angular hit occurs for the given ray. An angular hit is considered an intersection with
     // the ray and an angular section. The angular sections live in the XY plane.
-    AngularHitParameters angularHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                    const RaySegment &RS, const std::array<double, 2> &collinear_times,
-                                    int current_voxel_ID_theta, double t, double t_end) noexcept {
+    inline AngularHitParameters angularHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
+                                           const RaySegment &RS, const std::array<double, 2> &collinear_times,
+                                           int current_voxel_ID_theta, double t, double t_end) noexcept {
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxAngular(current_voxel_ID_theta).P1,
                              grid.pMaxAngular(current_voxel_ID_theta).P2, 0.0);
@@ -386,9 +386,9 @@ namespace svr {
     // Determines whether an azimuthal hit occurs for the given ray. An azimuthal hit is
     // considered an intersection with the ray and an azimuthal section.
     // The azimuthal sections live in the XZ plane.
-    AzimuthalHitParameters azimuthalHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                        const RaySegment &RS, const std::array<double, 2> &collinear_times,
-                                        int current_voxel_ID_phi, double t, double t_end) noexcept {
+    inline AzimuthalHitParameters azimuthalHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
+                                               const RaySegment &RS, const std::array<double, 2> &collinear_times,
+                                               int current_voxel_ID_phi, double t, double t_end) noexcept {
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxAzimuthal(current_voxel_ID_phi).P1, 0.0,
                              grid.pMaxAzimuthal(current_voxel_ID_phi).P2);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -209,8 +209,9 @@ namespace svr {
     // as well as avoiding unnecessary duplicate calculations that have already been done in the initialization phase.
     // This follows closely the mathematics presented in:
     // http://cas.xav.free.fr/Graphics%20Gems%204%20-%20Paul%20S.%20Heckbert.pdf
-    inline RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid, RadialHitData &rh_data,
-                                         int current_voxel_ID_r, double t, double t_end) noexcept {
+    inline RadialHitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
+                                         const RadialHitData &rh_data, int current_voxel_ID_r,
+                                         double t, double t_end) noexcept {
         const std::size_t voxel_idx = current_voxel_ID_r - 1;
         const double current_radius = grid.deltaRadii(voxel_idx);
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -121,8 +121,7 @@ namespace svr {
         // More information on this use case can be found at:
         // http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
         inline double raySegmentIntersectionTimeAt(double intersect_param) const noexcept {
-            const auto idx = ray_->NonZeroDirectionIndex();
-            return (P1_[idx] + ray_segment_[idx] * intersect_param - ray_->origin()[idx]) * ray_->invDirection()[idx];
+            return (P1_[NZDI_] + ray_segment_[NZDI_] * intersect_param - ray_->origin()[NZDI_]) * ray_->invDirection()[NZDI_];
         }
 
         inline const BoundVec3 &P1() const noexcept { return P1_; }
@@ -134,6 +133,9 @@ namespace svr {
     private:
         // The associated ray for which the segment (P1, P2) refers to.
         const Ray *ray_;
+
+        // The non-zero direction index of the ray.
+        const DirectionIndex NZDI_ = ray_->NonZeroDirectionIndex();
 
         // The begin point of the ray segment.
         BoundVec3 P1_;
@@ -210,7 +212,6 @@ namespace svr {
                                          int current_voxel_ID_r, double t, double t_end) noexcept {
         const std::size_t voxel_idx = current_voxel_ID_r - 1;
         const double current_radius = grid.deltaRadii(voxel_idx);
-
 
         // Find the intersection times for the ray and the previous radial disc.
         const std::size_t previous_idx = std::min(voxel_idx + 1, grid.numRadialVoxels() - 1);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -307,13 +307,13 @@ namespace svr {
         }
 
         GenHitParameters params;
-        if (is_intersect_max && !is_intersect_min && !is_collinear_min && t_max_within_bounds) {
+        if (t_max_within_bounds && is_intersect_max && !is_intersect_min && !is_collinear_min) {
             params.tStep = 1;
             params.tMax = t_max;
             params.within_bounds = true;
             return params;
         }
-        if (is_intersect_min && !is_intersect_max && !is_collinear_max && t_min_within_bounds) {
+        if (t_min_within_bounds && is_intersect_min && !is_intersect_max && !is_collinear_max) {
             params.tStep = -1;
             params.tMax = t_min;
             params.within_bounds = true;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -217,8 +217,8 @@ namespace svr {
 
         // Find the intersection times for the ray and the previous radial disc.
         const std::size_t previous_idx = std::min(voxel_idx + 1, grid.numRadialVoxels() - 1);
-        double r_a = grid.deltaRadiiSquared( previous_idx -
-                                             (grid.deltaRadiiSquared(previous_idx) < rh_data.rsvdMinusVSquared()) );
+        const double r_a = grid.deltaRadiiSquared(previous_idx -
+                                                  (grid.deltaRadiiSquared(previous_idx) < rh_data.rsvdMinusVSquared()));
         const double d_a = std::sqrt(r_a - rh_data.rsvdMinusVSquared());
 
         std::array<double, 4> intersection_times;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -238,15 +238,14 @@ namespace svr {
         const auto intersection_time_it = std::find_if(intersection_times.cbegin(),
                                                        intersection_times.cend(),
                                                     [t](double i)->double{ return i > t;});
-        const double intersection_time = *intersection_time_it;
 
-        if (intersection_time_it == intersection_times.cend() ||
-            !(lessThan(t, intersection_time) && lessThan(intersection_time, t_end))) {
+        if (intersection_time_it == intersection_times.cend()) {
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
                     .previous_transition_flag=false,
-                    .within_bounds=false};
+                    .within_bounds=false };
         }
+        const double intersection_time = *intersection_time_it;
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isEqual(r_new, current_radius);
         const bool is_not_tangential_hit = !(isEqual(intersection_times[0], intersection_times[1]));
@@ -254,8 +253,7 @@ namespace svr {
                 .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&
                              !is_radial_transition && lessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
-                .within_bounds=true
-        };
+                .within_bounds= lessThan(t, intersection_time) && lessThan(intersection_time, t_end) };
     }
 
     // A generalized version of the latter half of the angular and azimuthal hit parameters. Since the only difference

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -44,7 +44,7 @@ namespace svr {
                 delta_theta_(TAU / num_angular_voxels),
                 delta_phi_(TAU / num_azimuthal_voxels) {
 
-            delta_radii_.resize(num_radial_voxels);
+            delta_radii_.resize(num_radial_voxels + 1);
             double current_delta_radius = delta_radius_ * num_radial_voxels;
             std::generate(delta_radii_.begin(), delta_radii_.end(),
                           [&]() -> double {
@@ -52,7 +52,7 @@ namespace svr {
                               current_delta_radius -= delta_radius_;
                               return old_delta_radius;
                           });
-            delta_radii_sq_.resize(num_radial_voxels);
+            delta_radii_sq_.resize(num_radial_voxels + 1);
             std::transform(delta_radii_.cbegin(), delta_radii_.cend(), delta_radii_sq_.begin(),
                            [](double dR) -> double { return dR * dR; });
 


### PR DESCRIPTION
- Use previously calculated deltaRadii, deltaRadiiSquared to avoid duplicated calculations.
- Use a double[] to avoid a branch prediction when calculating the previous index.
- Use std::min, std::max on size_t instead of floats.
- Avoid calculating ```X - rh_data.rsvdMinusVSquared()``` unless the condition is true. This is derived in the following way:
```
=> X - ray_sphere_vector_dot - v * v < 0.0
=> X - rh_data.rsvdMinusVSquared() < 0.0
=> X < rh_data.rsvdMinusVSquared()
```
- Early exits for generalizedPlaneHit() in the case where the calculated ```t``` value(s) are not within bounds.
- Save ray->NZD as a member of RaySegment.

This PR lessens the 256^2 rays, 128^3 voxels orthographic trace to less than 0.95 seconds consistently on my MacBook Air 2013.