### PR TITLE
Add corner case tests for when the ray originates inside the sphere, address orthographic case.

### DIFF
--- a/cpp/cython/cython_SVR_tests.py
+++ b/cpp/cython/cython_SVR_tests.py
@@ -96,9 +96,9 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
                                                   num_angular_sections, num_azimuthal_sections, sphere_center,
                                                   sphere_max_radius, t_begin, t_end)
-        expected_radial_voxels = [3,2,1]
-        expected_theta_voxels = [3,3,3]
-        expected_phi_voxels = [3,3,3]
+        expected_radial_voxels = [4,3,2,1]
+        expected_theta_voxels = [3,3,3,3]
+        expected_phi_voxels = [0,0,0,0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_ends_within_sphere(self):

--- a/cpp/cython/cython_SVR_tests.py
+++ b/cpp/cython/cython_SVR_tests.py
@@ -81,6 +81,26 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_phi_voxels = [1,1,1,0,0,3,3,3,3]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_ray_begins_within_sphere_and_begin_time_is_not_zero(self):
+        ray_origin = np.array([-3.0, 4.0, 5.0])
+        ray_direction = np.array([1.0, -1.0, -1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 5.0
+        t_end = 30.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [3,2,1]
+        expected_theta_voxels = [3,3,3]
+        expected_phi_voxels = [3,3,3]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
     def test_ray_ends_within_sphere(self):
         ray_origin = np.array([13.0, -15.0, 16.0])
         ray_direction = np.array([-1.5, 1.2, -1.5])
@@ -99,6 +119,26 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1, 2, 2, 3]
         expected_theta_voxels = [3, 3, 2, 2]
         expected_phi_voxels = [0, 0, 1, 1]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_and_ends_within_sphere(self):
+        ray_origin = np.array([-3.0, 4.0, 5.0])
+        ray_direction = np.array([1.0, -1.0, -1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 5.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [2,3,4,4,4]
+        expected_theta_voxels = [1,1,1,0,3]
+        expected_phi_voxels = [1,1,1,0,0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_slight_offset_in_XY_plane(self):

--- a/cpp/cython/cython_SVR_tests.py
+++ b/cpp/cython/cython_SVR_tests.py
@@ -1,5 +1,7 @@
 '''
 Testing for cythonized version of the spherical coordinate voxel traversal algorithm.
+To compile SVR code:
+    python cython_SVR_setup.py build_ext --inplace
 '''
 
 import unittest
@@ -60,8 +62,8 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_within_sphere(self):
-        ray_origin = np.array([-15.0, 15.0, 15.0])
-        ray_direction = np.array([1.6, -1.2, -1.3])
+        ray_origin = np.array([-3.0, 4.0, 5.0])
+        ray_direction = np.array([1.0, -1.0, -1.0])
         min_bound = np.array([-20.0, -20.0, -20.0])
         max_bound = np.array([20.0, 20.0, 20.0])
         sphere_center = np.array([0.0, 0.0, 0.0])
@@ -69,14 +71,14 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         num_radial_sections = 4
         num_angular_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 8.7
+        t_begin = 0.0
         t_end = 30.0
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
                                                   num_angular_sections, num_azimuthal_sections, sphere_center,
                                                   sphere_max_radius, t_begin, t_end)
-        expected_radial_voxels = [3, 4, 4, 3, 3, 3, 2, 1]
-        expected_theta_voxels = [0, 0, 3, 3, 3, 3, 3, 3]
-        expected_phi_voxels = [0, 0, 0, 0, 0, 3, 3, 3]
+        expected_radial_voxels = [2,3,4,4,4,4,3,2,1]
+        expected_theta_voxels = [1,1,1,0,3,3,3,3,3]
+        expected_phi_voxels = [1,1,1,0,0,3,3,3,3]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_ends_within_sphere(self):
@@ -455,6 +457,47 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_theta_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
         expected_phi_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_in_outermost_radius_and_ends_within_sphere(self):
+        ray_origin = np.array([-4.0, -4.0, -6.0])
+        ray_direction = np.array([1.3, 1.0, 1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 4.3
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1, 2, 3, 3, 4, 4]
+        expected_theta_voxels = [2, 2, 2, 3, 3, 0]
+        expected_phi_voxels = [2, 2, 2, 3, 3, 3]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_at_sphere_origin(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [4, 3, 2, 1]
+        expected_theta_voxels = [1, 1, 1, 1]
+        expected_phi_voxels = [2, 2, 2, 2]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
 
 
 if __name__ == '__main__':

--- a/cpp/cython/cython_SVR_tests.py
+++ b/cpp/cython/cython_SVR_tests.py
@@ -436,5 +436,26 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_phi_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_time_begins_is_not_zero(self):
+        ray_origin = np.array([-15.0, 15.0, 15.0])
+        ray_direction = np.array([1.0, -1.0, -1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.01
+        t_end = 50.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
+        expected_phi_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/cython/cython_SVR_tests.py
+++ b/cpp/cython/cython_SVR_tests.py
@@ -59,6 +59,46 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_ray_begins_within_sphere(self):
+        ray_origin = np.array([-15.0, 15.0, 15.0])
+        ray_direction = np.array([1.6, -1.2, -1.3])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 8.7
+        t_end = 30.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [3, 4, 4, 3, 3, 3, 2, 1]
+        expected_theta_voxels = [0, 0, 3, 3, 3, 3, 3, 3]
+        expected_phi_voxels = [0, 0, 0, 0, 0, 3, 3, 3]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_ends_within_sphere(self):
+        ray_origin = np.array([13.0, -15.0, 16.0])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 10.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                  sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1, 2, 2, 3]
+        expected_theta_voxels = [3, 3, 2, 2]
+        expected_phi_voxels = [0, 0, 1, 1]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
     def test_ray_slight_offset_in_XY_plane(self):
         ray_origin = np.array([-13.0, -13.0, -13.0])
         ray_direction = np.array([1.0, 1.5, 1.0])

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -522,7 +522,7 @@ namespace svr {
 
         const FreeVec3 P_sphere = ray_origin_is_outside_grid ?
                                   grid.sphereCenter() - ray.pointAtParameter(std::min(t1,t2)) :
-                                  isEqual(point_at_t_begin, grid.sphereCenter()) ?          // Need to perturb slightly.
+                                  isEqual(point_at_t_begin, grid.sphereCenter()) ? // Need to perturb slightly.
                                   grid.sphereCenter() - ray.pointAtParameter(t_begin + 0.1)   :
                                   ray_sphere_vector;
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -13,6 +13,7 @@ namespace svr {
 
     // Epsilon used for floating point comparisons in Knuth's algorithm.
     constexpr double ABS_EPSILON = 1e-12;
+    constexpr double REL_EPSILON = 1e-8;
 
     // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
     enum VoxelIntersectionType {
@@ -156,14 +157,20 @@ namespace svr {
     //        Donald. E. Knuth, 1998, Addison-Wesley Longman, Inc., ISBN 0-201-89684-2, Addison-Wesley Professional;
     //        3rd edition. (The relevant equations are in §4.2.2, Eq. 36 and 37.)
     inline bool isEqual(double a, double b) noexcept {
-        return std::abs(a - b) <= ABS_EPSILON;
+        const double diff = std::abs(a - b);
+        if (diff <= ABS_EPSILON) { return true; }
+        return diff <= std::max(std::abs(a), std::abs(b)) * REL_EPSILON;
     }
 
     // Overloaded version that checks for Knuth equality with vector cartesian coordinates.
     inline bool isEqual(const Vec3 &a, const Vec3 &b) noexcept {
-        return std::abs(a.x() - b.x()) <= ABS_EPSILON &&
-               std::abs(a.y() - b.y()) <= ABS_EPSILON &&
-               std::abs(a.z() - b.z()) <= ABS_EPSILON;
+        const double diff_x = std::abs(a.x() - b.x());
+        const double diff_y = std::abs(a.y() - b.y());
+        const double diff_z = std::abs(a.z() - b.z());
+        if (diff_x <= ABS_EPSILON && diff_y <= ABS_EPSILON && diff_z <= ABS_EPSILON) { return true; }
+        return diff_x <= std::max(std::abs(a.x()), std::abs(b.x())) * REL_EPSILON &&
+               diff_y <= std::max(std::abs(a.y()), std::abs(b.y())) * REL_EPSILON &&
+               diff_z <= std::max(std::abs(a.z()), std::abs(b.z())) * REL_EPSILON;
     }
 
     // Checks to see if a is strictly less than b with an absolute epsilon.

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -443,7 +443,14 @@ namespace svr {
     // and floating point calculations.
     inline void initializeVoxelBoundarySegments(std::vector<svr::LineSegment> &P_angular,
                                                 std::vector<svr::LineSegment> &P_azimuthal,
+                                                bool ray_origin_is_outside_grid,
                                                 const svr::SphericalVoxelGrid &grid, double current_radius) noexcept {
+        if (ray_origin_is_outside_grid) {
+            P_angular = grid.pMaxAngular();
+            P_azimuthal = grid.pMaxAzimuthal();
+            return;
+        }
+
         if (grid.numAngularVoxels() == grid.numAzimuthalVoxels()) {
             std::transform(grid.angularTrigValues().cbegin(), grid.angularTrigValues().cend(),
                            P_angular.begin(), P_azimuthal.begin(),
@@ -511,10 +518,7 @@ namespace svr {
 
         std::vector<svr::LineSegment> P_angular(grid.numAngularVoxels() + 1);
         std::vector<svr::LineSegment> P_azimuthal(grid.numAzimuthalVoxels() + 1);
-        if (ray_origin_is_outside_grid) {
-            P_angular = grid.pMaxAngular();
-            P_azimuthal = grid.pMaxAzimuthal();
-        } else { initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius); }
+        initializeVoxelBoundarySegments(P_angular, P_azimuthal, ray_origin_is_outside_grid, grid, entry_radius);
 
         const FreeVec3 P_sphere = ray_origin_is_outside_grid ?
                                   grid.sphereCenter() - ray.pointAtParameter(std::min(t1,t2)) :

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -221,7 +221,6 @@ namespace svr {
                                          double t, double t_end) noexcept {
         const std::size_t voxel_idx = current_voxel_ID_r - 1;
         const double current_radius = grid.deltaRadii(voxel_idx);
-        printf("\nRadial Hit Entrance: < Current Voxel: %d, Current t: %f > -", current_voxel_ID_r, t);
 
         // Find the intersection times for the ray and the previous radial disc.
         const std::size_t previous_idx = std::min(voxel_idx + 1, grid.numRadialVoxels() - 1);
@@ -244,8 +243,6 @@ namespace svr {
             intersection_times[2] = ray.timeOfIntersectionAt(rh_data.v() - d_b);
             intersection_times[3] = ray.timeOfIntersectionAt(rh_data.v() + d_b);
         }
-        printf(" {it[0]: %f, it[1]: %f, it[2]: %f, it[3]: %f} ", intersection_times[0], intersection_times[1],
-                intersection_times[2], intersection_times[3]);
         const auto intersection_time_it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
                                                        [t](double i)->double{ return i > t; });
         if (intersection_time_it == intersection_times.cend()) {
@@ -256,8 +253,6 @@ namespace svr {
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isEqual(r_new, current_radius);
         const bool is_tangential_hit = isEqual(intersection_times[0], intersection_times[1]);
-        printf("- intersection_time: %f, is_radial_transition: %s, is_tangential_hit: %s",
-                intersection_time, is_radial_transition ? "True" : "False", is_tangential_hit ? "True" : "False");
         return {.tMaxR=intersection_time,
                 .tStepR=STEP[1 * !is_tangential_hit +
                              (!is_tangential_hit && !is_radial_transition
@@ -637,14 +632,15 @@ namespace svr {
         }
     }
 
-    std::vector<svr::SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
-                                                                         double *min_bound, double *max_bound,
-                                                                         std::size_t num_radial_voxels,
-                                                                         std::size_t num_angular_voxels,
-                                                                         std::size_t num_azimuthal_voxels,
-                                                                         double *sphere_center,
-                                                                         double sphere_max_radius, double t_begin,
-                                                                         double t_end) noexcept {
+    std::vector<svr::SphericalVoxel>
+    sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
+                                        double *min_bound, double *max_bound,
+                                        std::size_t num_radial_voxels,
+                                        std::size_t num_angular_voxels,
+                                        std::size_t num_azimuthal_voxels,
+                                        double *sphere_center,
+                                        double sphere_max_radius, double t_begin,
+                                        double t_end) noexcept {
         return svr::sphericalCoordinateVoxelTraversal(
                 Ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
                     FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2])),

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -113,7 +113,7 @@ namespace svr {
 
         // Updates the point P1 with the new time traversal time t. Similarly, updates the
         // segment denoted by P2 - P1.
-        inline void updateRaySegmentAtTime(double t) noexcept {
+        inline void updateAtTime(double t) noexcept {
             P1_ = ray_->pointAtParameter(t);
             ray_segment_ = P2_ - P1_;
         }
@@ -121,7 +121,7 @@ namespace svr {
         // Calculates the updated ray segment intersection point given an intersect parameter.
         // More information on this use case can be found at:
         // http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
-        inline double raySegmentIntersectionTimeAt(double intersect_param) const noexcept {
+        inline double intersectionTimeAt(double intersect_param) const noexcept {
             return (P1_[NZDI_] + ray_segment_[NZDI_] * intersect_param - ray_->origin()[NZDI_])
                    * ray_->invDirection()[NZDI_];
         }
@@ -287,7 +287,7 @@ namespace svr {
             b = perp_uw_min * inv_perp_uv_min;
             if (!((lessThan(a, 0.0) || lessThan(1.0, a)) || lessThan(b, 0.0) || lessThan(1.0, b))) {
                 is_intersect_min = true;
-                t_min = RS.raySegmentIntersectionTimeAt(b);
+                t_min = RS.intersectionTimeAt(b);
             }
         }
         double t_max = collinear_times[is_collinear_max];
@@ -298,7 +298,7 @@ namespace svr {
             b = perp_uw_max * inv_perp_uv_max;
             if (!((lessThan(a, 0.0) || lessThan(1.0, a)) || lessThan(b, 0.0) || lessThan(1.0, b))) {
                 is_intersect_max = true;
-                t_max = RS.raySegmentIntersectionTimeAt(b);
+                t_max = RS.intersectionTimeAt(b);
             }
         }
 
@@ -582,7 +582,7 @@ namespace svr {
         while (true) {
             const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
             radial_hit_data.updateTransitionFlag(radial_params.previous_transition_flag);
-            ray_segment.updateRaySegmentAtTime(t);
+            ray_segment.updateAtTime(t);
             const auto angular_params = angularHit(ray, grid, ray_segment, collinear_times,
                                                    current_voxel_ID_theta, t, t_end);
             const auto azimuthal_params = azimuthalHit(ray, grid, ray_segment, collinear_times,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -300,21 +300,15 @@ namespace svr {
         const bool t_max_within_bounds = lessThan(t, t_max) && lessThan(t_max, t_end);
         const bool t_min_within_bounds = lessThan(t, t_min) && lessThan(t_min, t_end);
         if (!t_max_within_bounds && !t_min_within_bounds) {
-            return { .tMax = std::numeric_limits<double>::max(),
-                     .tStep = 0,
-                     .within_bounds = false };
+            return { .tMax = std::numeric_limits<double>::max(), .tStep = 0, .within_bounds = false };
         }
 
 
         if (t_max_within_bounds && is_intersect_max && !is_intersect_min && !is_collinear_min) {
-            return { .tMax = t_max,
-                     .tStep = 1,
-                     .within_bounds = true };
+            return { .tMax = t_max, .tStep = 1, .within_bounds = true };
         }
         if (t_min_within_bounds && is_intersect_min && !is_intersect_max && !is_collinear_max) {
-            return { .tMax = t_min,
-                     .tStep = -1,
-                     .within_bounds = true };
+            return { .tMax = t_min, .tStep = -1, .within_bounds = true };
         }
         if ((is_intersect_min && is_intersect_max) ||
             (is_intersect_min && is_collinear_max) ||
@@ -328,24 +322,19 @@ namespace svr {
                 const double p2 = sphere_plane_center - max_radius_over_plane_length * b;
                 const int next_step = std::abs(current_voxel_ID - calculateVoxelID(P_max, p1, p2));
                 return { .tMax = t_max,
-                        .tStep = (lessThan(ray_plane_direction, 0.0) || lessThan(ray.direction().x(), 0.0)) ?
-                                 next_step : -next_step,
-                        .within_bounds = true };
+                         .tStep = (lessThan(ray_plane_direction, 0.0) || lessThan(ray.direction().x(), 0.0)) ?
+                                   next_step : -next_step,
+                         .within_bounds = true
+                };
             }
             if (t_min_within_bounds && (lessThan(t_min, t_max) || isEqual(t, t_max))) {
-                return { .tMax = t_min,
-                         .tStep = -1,
-                         .within_bounds = true };
+                return { .tMax = t_min, .tStep = -1, .within_bounds = true };
             }
             if (t_max_within_bounds && (lessThan(t_max, t_min) || isEqual(t, t_min))) {
-                return { .tMax = t_max,
-                         .tStep = 1,
-                         .within_bounds = true };
+                return { .tMax = t_max, .tStep = 1, .within_bounds = true };
             }
         }
-        return { .tMax = std::numeric_limits<double>::max(),
-                 .tStep = 0,
-                 .within_bounds = false };
+        return { .tMax = std::numeric_limits<double>::max(), .tStep = 0, .within_bounds = false };
     }
 
     // Determines whether an angular hit occurs for the given ray. An angular hit is considered an intersection with

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -246,33 +246,30 @@ namespace svr {
         const auto intersection_time_it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
                                                        [t](double i)->double{ return i > t; });
         if (intersection_time_it == intersection_times.cend()) {
-            return {.tMaxR=std::numeric_limits<double>::max(),
-                    .tStepR=0,
-                    .previous_transition_flag=false,
-                    .within_bounds=false };
+            return {.tMaxR=std::numeric_limits<double>::max(), .tStepR=0,
+                    .previous_transition_flag=false, .within_bounds=false };
         }
         const double intersection_time = *intersection_time_it;
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isEqual(r_new, current_radius);
-        const bool is_not_tangential_hit = !(isEqual(intersection_times[0], intersection_times[1]));
+        const bool is_tangential_hit = isEqual(intersection_times[0], intersection_times[1]);
         return {.tMaxR=intersection_time,
-                .tStepR=STEP[1 * is_not_tangential_hit + (is_not_tangential_hit &&
-                             !is_radial_transition && lessThan(r_new, current_radius))],
+                .tStepR=STEP[1 * !is_tangential_hit +
+                             (!is_tangential_hit && !is_radial_transition
+                              && lessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds= lessThan(t, intersection_time) && lessThan(intersection_time, t_end) };
     }
 
     // A generalized version of the latter half of the angular and azimuthal hit parameters. Since the only difference
     // is the 2-d plane for which they exist in, this portion can be generalized to a single function call.
-    // The variables that are generalized take the form of *_plane_*, such as ray_plane_direction. If this called in
-    // AngularHit(), ray_plane_direction == ray.direction.y(). The calculations presented below follow closely the
-    // works of [Foley et al, 1996], [O'Rourke, 1998].
+    // The calculations presented below follow closely the works of [Foley et al, 1996], [O'Rourke, 1998].
     // Reference: http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
     GenHitParameters
     generalizedPlaneHit(const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min, double perp_uv_max,
                         double perp_uw_min, double perp_uw_max, double perp_vw_min, double perp_vw_max,
                         const RaySegment &RS, const std::array<double, 2> &collinear_times, double t, double t_end,
-                        double ray_plane_direction, double sphere_plane_center,
+                        double ray_direction_2, double sphere_center_2,
                         const std::vector<svr::LineSegment> &P_max, int current_voxel_ID) noexcept {
         const bool is_parallel_min = isEqual(perp_uv_min, 0.0);
         const bool is_collinear_min = is_parallel_min && isEqual(perp_uw_min, 0.0) && isEqual(perp_vw_min, 0.0);
@@ -321,13 +318,13 @@ namespace svr {
             if (t_min_within_bounds && isEqual(t_min, t_max)) {
                 const double perturbed_t = 0.1;
                 a = -ray.direction().x() * perturbed_t;
-                b = -ray_plane_direction * perturbed_t;
+                b = -ray_direction_2 * perturbed_t;
                 const double max_radius_over_plane_length = grid.sphereMaxRadius() / std::sqrt(a * a + b * b);
                 const double p1 = grid.sphereCenter().x() - max_radius_over_plane_length * a;
-                const double p2 = sphere_plane_center - max_radius_over_plane_length * b;
+                const double p2 = sphere_center_2 - max_radius_over_plane_length * b;
                 const int next_step = std::abs(current_voxel_ID - calculateVoxelID(P_max, p1, p2));
                 return { .tMax = t_max,
-                         .tStep = (lessThan(ray_plane_direction, 0.0) || lessThan(ray.direction().x(), 0.0)) ?
+                         .tStep = (lessThan(ray_direction_2, 0.0) || lessThan(ray.direction().x(), 0.0)) ?
                                    next_step : -next_step,
                          .within_bounds = true
                 };
@@ -487,12 +484,11 @@ namespace svr {
                                                                        double t_begin, double t_end) noexcept {
         // Determine ray location at t_begin.
         const BoundVec3 point_at_t_begin = ray.pointAtParameter(t_begin);
-        const FreeVec3 ray_sphere_vector = grid.sphereCenter() - point_at_t_begin;
-        const FreeVec3 ray_sphere_vector_tzero = t_begin == 0.0 ? ray_sphere_vector :
-                                                                  grid.sphereCenter() - ray.pointAtParameter(0.0);
+        const FreeVec3 rsv = grid.sphereCenter() - point_at_t_begin;   // Ray Sphere Vector.
+        const FreeVec3 rsv_tz = t_begin == 0.0 ? rsv : grid.sphereCenter() - ray.pointAtParameter(0.0);
 
         std::size_t idx = grid.numRadialVoxels();
-        const double rsvd_begin = ray_sphere_vector.dot(ray_sphere_vector);
+        const double rsvd_begin = rsv.dot(rsv);
         const auto it = std::find_if(grid.deltaRadiiSquared().crbegin() + 1,
                                      grid.deltaRadiiSquared().crend(),
                                      [rsvd_begin, &idx](double dR_squared)-> bool {
@@ -501,13 +497,13 @@ namespace svr {
         });
         const bool ray_origin_is_outside_grid = (it == grid.deltaRadiiSquared().crend());
         const double max_radius_squared = grid.deltaRadiiSquared()[0];
-        const double entry_radius_squared = !ray_origin_is_outside_grid ? *it : max_radius_squared;
+        const double entry_radius_squared = ray_origin_is_outside_grid ? max_radius_squared : *it;
         const double entry_radius = grid.deltaRadii()[idx];
 
         // Find the intersection times for the ray and the radial shell containing the parameter point at t_begin.
         // This will determine if the ray intersects the sphere.
-        const double rsvd = ray_sphere_vector_tzero.dot(ray_sphere_vector_tzero); // Ray Sphere Vector Dot product
-        const double v = ray_sphere_vector_tzero.dot(ray.unitDirection().to_free());
+        const double rsvd = rsv_tz.dot(rsv_tz); // Ray Sphere Vector Dot product at time zero.
+        const double v = rsv_tz.dot(ray.unitDirection().to_free());
         const double rsvd_minus_v_squared = rsvd - v * v;
         const double discriminant = entry_radius_squared - rsvd_minus_v_squared;
 
@@ -532,10 +528,8 @@ namespace svr {
 
         const FreeVec3 P_sphere = ray_origin_is_outside_grid ?
                                   grid.sphereCenter() - ray.pointAtParameter(std::min(t1,t2)) :
-                                  isEqual(point_at_t_begin, grid.sphereCenter()) ? // Need to perturb slightly.
-                                  grid.sphereCenter() - ray.pointAtParameter(t_begin + 0.1)   :
-                                  ray_sphere_vector;
-
+                                  isEqual(point_at_t_begin, grid.sphereCenter())              ?
+                                  grid.sphereCenter() - ray.pointAtParameter(t_begin + 0.1)   :   rsv;
         double p_x, p_y, p_z;
         const double angular_len = P_sphere.x() * P_sphere.x() + P_sphere.y() * P_sphere.y();
         if (isEqual(angular_len, 0.0)) {
@@ -639,15 +633,12 @@ namespace svr {
                             (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
                     break;
                 }
-                case None: {
-                    return voxels;
-                }
+                case None: return voxels;
             }
             voxels.push_back({.radial_voxel=current_voxel_ID_r,
                               .angular_voxel=current_voxel_ID_theta,
                               .azimuthal_voxel=current_voxel_ID_phi});
         }
-        return voxels;
     }
 
     std::vector<svr::SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -236,10 +236,8 @@ namespace svr {
             intersection_times[2] = ray.timeOfIntersectionAt(rh_data.v() - d_b);
             intersection_times[3] = ray.timeOfIntersectionAt(rh_data.v() + d_b);
         }
-        const auto intersection_time_it = std::find_if(intersection_times.cbegin(),
-                                                       intersection_times.cend(),
-                                                    [t](double i)->double{ return i > t;});
-
+        const auto intersection_time_it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
+                                                       [t](double i)->double{ return i > t; });
         if (intersection_time_it == intersection_times.cend()) {
             return {.tMaxR=std::numeric_limits<double>::max(),
                     .tStepR=0,
@@ -489,7 +487,6 @@ namespace svr {
         const double max_radius_squared = grid.deltaRadiiSquared()[0];
         const double entry_radius_squared = !ray_origin_is_outside_grid ? *it : max_radius_squared;
         const double entry_radius = grid.deltaRadii()[idx];
-        printf("entry_radius: %f {%lu}", entry_radius, idx);
 
         // Find the intersection times for the ray and the radial shell containing the parameter point at t_begin.
         // This will determine if the ray intersects the sphere.
@@ -504,7 +501,6 @@ namespace svr {
         // Need to use a non-zero direction to determine this.
         const double t1 = ray.timeOfIntersectionAt(v - d);
         const double t2 = ray.timeOfIntersectionAt(v + d);
-        printf("\n t1: %f, t2: %f \n", t1, t2);
 
         if (((t1 < t_begin && t2 < t_begin) && ray_origin_is_outside_grid) || isEqual(t1, t2)) {
             // Case 1: No intersection.
@@ -515,7 +511,10 @@ namespace svr {
 
         std::vector<svr::LineSegment> P_angular(grid.numAngularVoxels() + 1);
         std::vector<svr::LineSegment> P_azimuthal(grid.numAzimuthalVoxels() + 1);
-        initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius);
+        if (ray_origin_is_outside_grid) {
+            P_angular = grid.pMaxAngular();
+            P_azimuthal = grid.pMaxAzimuthal();
+        } else { initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius); }
 
         const FreeVec3 P_sphere = ray_origin_is_outside_grid ?
                                   grid.sphereCenter() - ray.pointAtParameter(std::min(t1,t2)) :

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -18,15 +18,13 @@ namespace {
     // (-1000.0, -1000.0) -> (1000.0, 1000.0) while remaining outside the sphere in the Z plane.
     // Since the maximum sphere radius is 10^4, this ensures all rays will intersect.
     void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
-        const std::size_t voxel_count = X;
-        const std::size_t ray_count = Y;
         const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
         const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0 * 1000.0;
-        const std::size_t num_radial_sections = voxel_count;
-        const std::size_t num_angular_sections = voxel_count;
-        const std::size_t num_azimuthal_sections = voxel_count;
+        const std::size_t num_radial_sections = Y;
+        const std::size_t num_angular_sections = Y;
+        const std::size_t num_azimuthal_sections = Y;
         const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const double t_begin = 0.0;
@@ -36,15 +34,14 @@ namespace {
         double ray_origin_y = -1000.0;
         const double ray_origin_z = -(sphere_max_radius + 1000.0);
 
-        const double ray_origin_plane_movement = 2000.0 / ray_count;
-        const std::size_t end_of_column = ray_count - 1;
-        for (std::size_t i = 0; i < ray_count; ++i) {
-            for (std::size_t j = 0; j < ray_count; ++j) {
+        const double ray_origin_plane_movement = 2000.0 / X;
+        for (std::size_t i = 0; i < X; ++i) {
+            for (std::size_t j = 0; j < X; ++j) {
                 const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
                 const FreeVec3  ray_direction(0.0, 0.0, 1.0);
                 const auto actual_voxels = sphericalCoordinateVoxelTraversal(Ray(ray_origin, ray_direction),
                                                                              grid, t_begin, t_end);
-                ray_origin_y = (j == end_of_column) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
+                ray_origin_y = (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
             }
             ray_origin_x += ray_origin_plane_movement;
         }
@@ -183,13 +180,13 @@ namespace {
 
     static void Orthographic_128SquaredRays_64CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
-            orthographicTraverseXSquaredRaysinYCubedVoxels(64, 128);
+            orthographicTraverseXSquaredRaysinYCubedVoxels(128, 64);
         }
     }
 
     static void Orthographic_256SquaredRays_128CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
-            orthographicTraverseXSquaredRaysinYCubedVoxels(128, 256);
+            orthographicTraverseXSquaredRaysinYCubedVoxels(256, 128);
         }
     }
 

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -8,6 +8,47 @@
 // To use Google Benchmark, see: https://github.com/google/benchmark#installation
 
 namespace {
+    // Sends X^2 rays through a Y^3 voxel sphere with maximum radius 10^4.
+    // The set up is the following:
+    // This traversal is orthographic in nature, and all rays will intersect the sphere.
+    // In the X plane: Ray origin moves incrementally from [-1000.0, 1000.0].
+    // In the Y plane: Ray origin moves incrementally from [-1000.0, 1000.0].
+    // In the Z plane: Ray origin begins at -(10^4 + 1000.0). It does not move in the Z plane.
+    // From this, one can infer that the ray moves incrementally in the XY plane from
+    // (-1000.0, -1000.0) -> (1000.0, 1000.0) while remaining outside the sphere in the Z plane.
+    // Since the maximum sphere radius is 10^4, this ensures all rays will intersect.
+    void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
+        const std::size_t voxel_count = X;
+        const std::size_t ray_count = Y;
+        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0 * 1000.0;
+        const std::size_t num_radial_sections = voxel_count;
+        const std::size_t num_angular_sections = voxel_count;
+        const std::size_t num_azimuthal_sections = voxel_count;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 2.0;
+
+        double ray_origin_x = -1000.0;
+        double ray_origin_y = -1000.0;
+        const double ray_origin_z = -(sphere_max_radius + 1000.0);
+
+        const double ray_origin_plane_movement = 2000.0 / ray_count;
+        const std::size_t end_of_column = ray_count - 1;
+        for (std::size_t i = 0; i < ray_count; ++i) {
+            for (std::size_t j = 0; j < ray_count; ++j) {
+                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
+                const FreeVec3  ray_direction(0.0, 0.0, 1.0);
+                const auto actual_voxels = sphericalCoordinateVoxelTraversal(Ray(ray_origin, ray_direction),
+                                                                             grid, t_begin, t_end);
+                ray_origin_y = (j == end_of_column) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
+            }
+            ray_origin_x += ray_origin_plane_movement;
+        }
+    }
 
     static void TraversalOne(benchmark::State &state) {
         for (auto _ : state) {
@@ -140,79 +181,15 @@ namespace {
         }
     }
 
-    // 128^3 domain with 256^2 rays for a scratch paper benchmark.
-    // In this case, we can imagine the rays form a square projection
-    // on the sphere, and thus not all rays will intersect.
-    // Rays are perpendicular to the XY Plane.
-    static void OrthographicRayTracing(benchmark::State &state) {
+    static void Orthographic_128SquaredRays_64CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
-            const std::size_t voxel_count = 128;
-            const std::size_t ray_count = 256;
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 1000.0;
-            const std::size_t num_radial_sections = voxel_count;
-            const std::size_t num_angular_sections = voxel_count;
-            const std::size_t num_azimuthal_sections = voxel_count;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const double t_begin = 0.0;
-            const double t_end = sphere_max_radius * 2.0;
-
-            const double ray_origin_begin = -1000.0;
-            double ray_origin_x = ray_origin_begin;
-            double ray_origin_y = ray_origin_begin;
-            const double ray_origin_z = -sphere_max_radius - 100.0;
-            const double ray_movement = std::abs(ray_origin_begin) * 2.0 / ray_count;
-            for (std::size_t i = 0; i < ray_count; ++i) {
-                for (std::size_t j = 0; j < ray_count; ++j) { // 256^2 iterations.
-                    const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-                    const FreeVec3 ray_direction(0.0, 0.0, 1.0);
-                    const Ray ray(ray_origin, ray_direction);
-                    const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-                    ray_origin_y = (j == ray_count - 1) ? ray_origin_begin : ray_origin_y + ray_movement;
-                }
-                ray_origin_x += ray_movement;
-            }
+            orthographicTraverseXSquaredRaysinYCubedVoxels(64, 128);
         }
     }
 
-    // 64^3 domain with 256^2 rays for a scratch paper benchmark.
-    // Because the sphere maximum radius is 10x larger than the ray
-    // origin begin, all rays intersect the sphere.
-    // Rays are perpendicular to the XY Plane.
-    static void OrthographicAllRaysIntersect(benchmark::State &state) {
+    static void Orthographic_256SquaredRays_128CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
-            const std::size_t voxel_count = 64;
-            const std::size_t ray_count = 256;
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 1000.0 * 10.0;
-            const std::size_t num_radial_sections = voxel_count;
-            const std::size_t num_angular_sections = voxel_count;
-            const std::size_t num_azimuthal_sections = voxel_count;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const double t_begin = 0.0;
-            const double t_end = sphere_max_radius * 2.0;
-
-            const double ray_origin_begin = -1000.0;
-            double ray_origin_x = ray_origin_begin;
-            double ray_origin_y = ray_origin_begin;
-            const double ray_origin_z = -sphere_max_radius - 100.0;
-            const double ray_movement = std::abs(ray_origin_begin) * 2.0 / ray_count;
-            for (std::size_t i = 0; i < ray_count; ++i) {
-                for (std::size_t j = 0; j < ray_count; ++j) { // 256^2 iterations.
-                    const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-                    const FreeVec3 ray_direction(0.0, 0.0, 1.0);
-                    const Ray ray(ray_origin, ray_direction);
-                    const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-                    ray_origin_y = (j == ray_count - 1) ? ray_origin_begin : ray_origin_y + ray_movement;
-                }
-                ray_origin_x += ray_movement;
-            }
+            orthographicTraverseXSquaredRaysinYCubedVoxels(128, 256);
         }
     }
 
@@ -222,8 +199,8 @@ namespace {
     BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
     BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
     BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
-    BENCHMARK(OrthographicRayTracing)->Unit(benchmark::kMillisecond);
-    BENCHMARK(OrthographicAllRaysIntersect)->Unit(benchmark::kMillisecond);
+    BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond);
+    BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(10);
 
 } // namespace
 

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -41,7 +41,6 @@ namespace {
                 const FreeVec3  ray_direction(0.0, 0.0, 1.0);
                 const auto actual_voxels = sphericalCoordinateVoxelTraversal(Ray(ray_origin, ray_direction),
                                                                              grid, t_begin, t_end);
-                const std::size_t last = actual_voxels.size() - 1;
                 ray_origin_y = (j == X - 1) ? -10000.0 : ray_origin_y + ray_origin_plane_movement;
             }
             ray_origin_x += ray_origin_plane_movement;

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -30,11 +30,11 @@ namespace {
         const double t_begin = 0.0;
         const double t_end = sphere_max_radius * 3;
 
-        double ray_origin_x = -1000.0;
-        double ray_origin_y = -1000.0;
+        double ray_origin_x = -10000.0;
+        double ray_origin_y = -10000.0;
         const double ray_origin_z = -(sphere_max_radius + 1.0);
 
-        const double ray_origin_plane_movement = 2000.0 / X;
+        const double ray_origin_plane_movement = 20000.0 / X;
         for (std::size_t i = 0; i < X; ++i) {
             for (std::size_t j = 0; j < X; ++j) {
                 const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
@@ -42,144 +42,9 @@ namespace {
                 const auto actual_voxels = sphericalCoordinateVoxelTraversal(Ray(ray_origin, ray_direction),
                                                                              grid, t_begin, t_end);
                 const std::size_t last = actual_voxels.size() - 1;
-                if (actual_voxels[0].radial_voxel != 1 || actual_voxels[last].radial_voxel != 1) {
-                    printf("\nDid not complete entire traversal.");
-                    printf("\nRay origin: {%f, %f, %f}", ray_origin_x, ray_origin_y, ray_origin_z);
-                }
-                ray_origin_y = (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
+                ray_origin_y = (j == X - 1) ? -10000.0 : ray_origin_y + ray_origin_plane_movement;
             }
             ray_origin_x += ray_origin_plane_movement;
-        }
-    }
-
-    static void TraversalOne(benchmark::State &state) {
-        for (auto _ : state) {
-            // Traversal from bottom left to upper right.
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 10000.0;
-            const std::size_t num_radial_sections = 10000;
-            const std::size_t num_angular_sections = 10000;
-            const std::size_t num_azimuthal_sections = 10000;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(-13000.0, -13000.0, -13000.0);
-            const FreeVec3 ray_direction(1.0, 1.0, 1.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 100000.0;
-            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        }
-    }
-
-    static void TraversalTwo(benchmark::State &state) {
-        for (auto _ : state) {
-            // Traversal from upper right to bottom left.
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 10000.0;
-            const std::size_t num_radial_sections = 10000;
-            const std::size_t num_angular_sections = 10000;
-            const std::size_t num_azimuthal_sections = 10000;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(13000.0, 13000.0, 13000.0);
-            const FreeVec3 ray_direction(-1.0, -1.0, -1.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 100000.0;
-            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        }
-    }
-
-    static void TraversalParallelX(benchmark::State &state) {
-        for (auto _ : state) {
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 10000.0;
-            const std::size_t num_radial_sections = 10000;
-            const std::size_t num_angular_sections = 10000;
-            const std::size_t num_azimuthal_sections = 10000;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(-13000.0, 10.0, 10.0);
-            const FreeVec3 ray_direction(1.0, 0.0, 0.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 100000.0;
-            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        }
-    }
-
-    static void TraversalParallelY(benchmark::State &state) {
-        for (auto _ : state) {
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 10000.0;
-            const std::size_t num_radial_sections = 10000;
-            const std::size_t num_angular_sections = 10000;
-            const std::size_t num_azimuthal_sections = 10000;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(10.0, -13000.0, 0.0);
-            const FreeVec3 ray_direction(0.0, 1.0, 0.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 100000.0;
-            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        }
-    }
-
-    static void TraversalParallelZ(benchmark::State &state) {
-        for (auto _ : state) {
-            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-            const double sphere_max_radius = 10000.0;
-            const std::size_t num_radial_sections = 10000;
-            const std::size_t num_angular_sections = 10000;
-            const std::size_t num_azimuthal_sections = 10000;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(10.0, 0.0, -13000.0);
-            const FreeVec3 ray_direction(0.0, 0.0, 1.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 100000.0;
-            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        }
-    }
-
-    static void MultipleRayNoIntersection(benchmark::State &state) {
-        for (auto _ : state) {
-            const int number_of_runs = 100000;
-            const BoundVec3 min_bound(0.0, 0.0, 0.0);
-            const BoundVec3 max_bound(30.0, 30.0, 30.0);
-            const BoundVec3 sphere_center(15.0, 15.0, 15.0);
-            const double sphere_max_radius = 10.0;
-            const std::size_t num_radial_sections = 4;
-            const std::size_t num_angular_sections = 8;
-            const std::size_t num_azimuthal_sections = 4;
-            const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                               num_angular_sections,
-                                               num_azimuthal_sections, sphere_center, sphere_max_radius);
-            const BoundVec3 ray_origin(3.0, 3.0, 3.0);
-            const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
-            const Ray ray(ray_origin, ray_direction);
-            const double t_begin = 0.0;
-            const double t_end = 15.0;
-            for (int i = 0; i < number_of_runs; ++i) {
-                sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-            }
         }
     }
 
@@ -219,14 +84,6 @@ namespace {
         }
     }
 
-
-
-    BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
-    BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
-    BENCHMARK(TraversalParallelX)->Unit(benchmark::kMillisecond);
-    BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
-    BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
-    BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
     BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
     BENCHMARK(Orthographic_256SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
     BENCHMARK(Orthographic_512SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -195,6 +195,12 @@ namespace {
         }
     }
 
+    static void Orthographic_512SquaredRays_64CubedVoxels(benchmark::State &state) {
+        for (auto _ : state) {
+            orthographicTraverseXSquaredRaysinYCubedVoxels(512, 64);
+        }
+    }
+
     static void Orthographic_128SquaredRays_128CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
             orthographicTraverseXSquaredRaysinYCubedVoxels(128, 128);
@@ -204,6 +210,12 @@ namespace {
     static void Orthographic_256SquaredRays_128CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
             orthographicTraverseXSquaredRaysinYCubedVoxels(256, 128);
+        }
+    }
+
+    static void Orthographic_512SquaredRays_128CubedVoxels(benchmark::State &state) {
+        for (auto _ : state) {
+            orthographicTraverseXSquaredRaysinYCubedVoxels(512, 128);
         }
     }
 
@@ -217,8 +229,10 @@ namespace {
     BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
     BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
     BENCHMARK(Orthographic_256SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
+    BENCHMARK(Orthographic_512SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
     BENCHMARK(Orthographic_128SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
     BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
+    BENCHMARK(Orthographic_512SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
 
 } // namespace
 

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -8,31 +8,31 @@
 // To use Google Benchmark, see: https://github.com/google/benchmark#installation
 
 namespace {
-    // Sends X^2 rays through a Y^3 voxel sphere with maximum radius 10^4.
+    // Sends X^2 rays through a Y^3 voxel sphere with maximum radius 10^6.
     // The set up is the following:
     // This traversal is orthographic in nature, and all rays will intersect the sphere.
     // In the X plane: Ray origin moves incrementally from [-1000.0, 1000.0].
     // In the Y plane: Ray origin moves incrementally from [-1000.0, 1000.0].
-    // In the Z plane: Ray origin begins at -(10^4 + 1000.0). It does not move in the Z plane.
+    // In the Z plane: Ray origin begins at -(10^6 + 1.0). It does not move in the Z plane.
     // From this, one can infer that the ray moves incrementally in the XY plane from
     // (-1000.0, -1000.0) -> (1000.0, 1000.0) while remaining outside the sphere in the Z plane.
-    // Since the maximum sphere radius is 10^4, this ensures all rays will intersect.
+    // Since the maximum sphere radius is 10^6, this ensures all rays will intersect.
     void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
-        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+        const BoundVec3 min_bound(-2000000.0, -2000000.0, -2000000.0);
+        const BoundVec3 max_bound(2000000.0, 2000000.0, 2000000.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10.0 * 1000.0;
+        const double sphere_max_radius = 10e6;
         const std::size_t num_radial_sections = Y;
         const std::size_t num_angular_sections = Y;
         const std::size_t num_azimuthal_sections = Y;
         const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
         const double t_begin = 0.0;
-        const double t_end = sphere_max_radius * 2.0;
+        const double t_end = sphere_max_radius * 3;
 
         double ray_origin_x = -1000.0;
         double ray_origin_y = -1000.0;
-        const double ray_origin_z = -(sphere_max_radius + 1000.0);
+        const double ray_origin_z = -(sphere_max_radius + 1.0);
 
         const double ray_origin_plane_movement = 2000.0 / X;
         for (std::size_t i = 0; i < X; ++i) {
@@ -41,6 +41,11 @@ namespace {
                 const FreeVec3  ray_direction(0.0, 0.0, 1.0);
                 const auto actual_voxels = sphericalCoordinateVoxelTraversal(Ray(ray_origin, ray_direction),
                                                                              grid, t_begin, t_end);
+                const std::size_t last = actual_voxels.size() - 1;
+                if (actual_voxels[0].radial_voxel != 1 || actual_voxels[last].radial_voxel != 1) {
+                    printf("\nDid not complete entire traversal.");
+                    printf("\nRay origin: {%f, %f, %f}", ray_origin_x, ray_origin_y, ray_origin_z);
+                }
                 ray_origin_y = (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
             }
             ray_origin_x += ray_origin_plane_movement;
@@ -196,8 +201,8 @@ namespace {
     BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
     BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
     BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
-    BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond);
-    BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(10);
+    BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(3);
+    BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(3);
 
 } // namespace
 

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -189,11 +189,25 @@ namespace {
         }
     }
 
+    static void Orthographic_256SquaredRays_64CubedVoxels(benchmark::State &state) {
+        for (auto _ : state) {
+            orthographicTraverseXSquaredRaysinYCubedVoxels(256, 64);
+        }
+    }
+
+    static void Orthographic_128SquaredRays_128CubedVoxels(benchmark::State &state) {
+        for (auto _ : state) {
+            orthographicTraverseXSquaredRaysinYCubedVoxels(128, 128);
+        }
+    }
+
     static void Orthographic_256SquaredRays_128CubedVoxels(benchmark::State &state) {
         for (auto _ : state) {
             orthographicTraverseXSquaredRaysinYCubedVoxels(256, 128);
         }
     }
+
+
 
     BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
     BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
@@ -201,8 +215,10 @@ namespace {
     BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
     BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
     BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
-    BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(3);
-    BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(3);
+    BENCHMARK(Orthographic_128SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
+    BENCHMARK(Orthographic_256SquaredRays_64CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
+    BENCHMARK(Orthographic_128SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
+    BENCHMARK(Orthographic_256SquaredRays_128CubedVoxels)->Unit(benchmark::kMillisecond)->Repetitions(1);
 
 } // namespace
 

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -36,6 +36,26 @@ namespace {
         EXPECT_THAT(phi_voxels, testing::ContainerEq(expected_phi_voxels));
     }
 
+    TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
+        const BoundVec3 min_bound(0.0, 0.0, 0.0);
+        const BoundVec3 max_bound(30.0, 30.0, 30.0);
+        const BoundVec3 sphere_center(15.0, 15.0, 15.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 8;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(3.0, 3.0, 3.0);
+        const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+
+        const double t_begin = 0.0;
+        const double t_end = 15.0;
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        EXPECT_EQ(actual_voxels.size(), 0);
+    }
+
     TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
@@ -56,6 +76,29 @@ namespace {
         const std::vector<int> expected_radial_voxels = {2,3,4,4,4,4,3,2,1};
         const std::vector<int> expected_theta_voxels = {1,1,1,0,3,3,3,3,3};
         const std::vector<int> expected_phi_voxels = {1,1,1,0,0,3,3,3,3};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsWithinSphereAndBeginTimeIsNotZero) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
+        const FreeVec3 ray_direction(1.0, -1.0, -1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 5.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {3,2,1};
+        const std::vector<int> expected_theta_voxels = {3,3,3};
+        const std::vector<int> expected_phi_voxels = {3,3,3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -82,24 +125,27 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
-        const BoundVec3 min_bound(0.0, 0.0, 0.0);
-        const BoundVec3 max_bound(30.0, 30.0, 30.0);
-        const BoundVec3 sphere_center(15.0, 15.0, 15.0);
+    TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
-        const std::size_t num_angular_sections = 8;
+        const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
         const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(3.0, 3.0, 3.0);
-        const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
+        const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
+        const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
-
         const double t_begin = 0.0;
-        const double t_end = 15.0;
+        const double t_end = 5.0;
+
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        EXPECT_EQ(actual_voxels.size(), 0);
+        const std::vector<int> expected_radial_voxels = {2,3,4,4,4};
+        const std::vector<int> expected_theta_voxels = {1,1,1,0,3};
+        const std::vector<int> expected_phi_voxels = {1,1,1,0,0};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
     TEST(SphericalCoordinateTraversal, SphereCenteredAtOrigin) {

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -528,10 +528,9 @@ namespace {
         std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
 
         std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
-        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
         std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
         std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
-
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -551,15 +550,14 @@ namespace {
         const FreeVec3 ray_direction(0.0, 0.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1); // { 1, 2, .. N-1, N, N-1, .. 3, 2, 1 }
+        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1); // { 1, 2, ... N-1, N, N-1, ... 3, 2, 1 }
         std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + num_radial_sections, 1);
         std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
 
         std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
+        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ..., 1, 1 }
         std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
-        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
-        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
-
+        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ..., 1, 1 }
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -584,10 +582,9 @@ namespace {
         std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
 
         std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
-        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
         std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
         std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
-
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -703,6 +700,35 @@ namespace {
         const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(DISABLED_SphericalCoordinateTraversal, TangentialHitWithinSphere) {
+        const BoundVec3 min_bound(-200000.0, -200000.0, -200000.0);
+        const BoundVec3 max_bound(200000.0, 200000.0, 200000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10e3;
+        const std::size_t num_radial_sections = 128;
+        const std::size_t num_angular_sections = 1;
+        const std::size_t num_azimuthal_sections = 1;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 3;
+        const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
+        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        // TODO: Fix expected values.
+        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1);
+        std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + num_radial_sections, 1);
+        std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
+
+        std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
+        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ..., 1, 1 }
+        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ..., 1, 1 }
+
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -35,7 +35,7 @@ namespace {
         EXPECT_THAT(phi_voxels, testing::ContainerEq(expected_phi_voxels));
     }
 
-    TEST(SphericalCoordinateTraversal, TestRayBeginsWithinSphere) {
+    TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -58,7 +58,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestRayEndsWithinSphere) {
+    TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -378,7 +378,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestOddNumberAngularSections) {
+    TEST(SphericalCoordinateTraversal, OddNumberAngularSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -401,7 +401,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestOddNumberAzimuthalSections) {
+    TEST(SphericalCoordinateTraversal, OddNumberAzimuthalSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -424,7 +424,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestLargeNumberOfRadialSections) {
+    TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -460,7 +460,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestLargeNumberOfAngularSections) {
+    TEST(SphericalCoordinateTraversal, LargeNumberOfAngularSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -483,7 +483,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestLargeNumberOfAzimuthalSections) {
+    TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -506,7 +506,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TestTimeBeginsIsNotZero) {
+    TEST(SphericalCoordinateTraversal, TimeBeginsIsNotZero) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -96,9 +96,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<int> expected_radial_voxels = {3,2,1};
-        const std::vector<int> expected_theta_voxels = {3,3,3};
-        const std::vector<int> expected_phi_voxels = {3,3,3};
+        const std::vector<int> expected_radial_voxels = {4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {3,3,3,3};
+        const std::vector<int> expected_phi_voxels = {0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -45,10 +45,10 @@ namespace {
         const std::size_t num_azimuthal_sections = 4;
         const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(-15.0, 15.0, 15.0);
+        const BoundVec3 ray_origin(-3.0, 3.0, 3.0);
         const FreeVec3 ray_direction(1.6, -1.2, -1.3);
         const Ray ray(ray_origin, ray_direction);
-        const double t_begin = 8.7;
+        const double t_begin = 0.0;
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
@@ -80,8 +80,6 @@ namespace {
         const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
-
-
 
     TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
         const BoundVec3 min_bound(0.0, 0.0, 0.0);
@@ -505,6 +503,29 @@ namespace {
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, TestTimeBeginsIsNotZero) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-15.0, 15.0, 15.0);
+        const FreeVec3 ray_direction(1.0, -1.0, -1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.01;
+        const double t_end = 50.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
+        const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
+        const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../spherical_volume_rendering_util.h"
+#include <algorithm>
 
 // Utilizes the Google Test suite.
 // To run, in the ../cpp/testing directory:
@@ -45,16 +46,16 @@ namespace {
         const std::size_t num_azimuthal_sections = 4;
         const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(-3.0, 3.0, 3.0);
-        const FreeVec3 ray_direction(1.6, -1.2, -1.3);
+        const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
+        const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<int> expected_radial_voxels = {3, 4, 4, 3, 3, 3, 2, 1};
-        const std::vector<int> expected_theta_voxels = {0, 0, 3, 3, 3, 3, 3, 3};
-        const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 3, 3, 3};
+        const std::vector<int> expected_radial_voxels = {2,3,4,4,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {1,1,1,0,3,3,3,3,3};
+        const std::vector<int> expected_phi_voxels = {1,1,1,0,0,3,3,3,3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -460,6 +461,90 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
+    TEST(SphericalCoordinateTraversal, LargeNumberRadialSectionsTwo) {
+        const BoundVec3 min_bound(-200000.0, -200000.0, -200000.0);
+        const BoundVec3 max_bound(200000.0, 200000.0, 200000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10e6;
+        const std::size_t num_radial_sections = 128;
+        const std::size_t num_angular_sections = 1;
+        const std::size_t num_azimuthal_sections = 1;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 3;
+        const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
+        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1); // { 1, 2, .. N-1, N, N-1, .. 3, 2, 1 }
+        std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + num_radial_sections, 1);
+        std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
+
+        std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
+        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
+        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
+
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, LargeNumberRadialSectionsThree) {
+        const BoundVec3 min_bound(-200000.0, -200000.0, -200000.0);
+        const BoundVec3 max_bound(200000.0, 200000.0, 200000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10e6;
+        const std::size_t num_radial_sections = 256;
+        const std::size_t num_angular_sections = 1;
+        const std::size_t num_azimuthal_sections = 1;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 3;
+        const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
+        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1); // { 1, 2, .. N-1, N, N-1, .. 3, 2, 1 }
+        std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + num_radial_sections, 1);
+        std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
+
+        std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
+        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
+        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
+
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, LargeNumberRadialSectionsFour) {
+        const BoundVec3 min_bound(-200000.0, -200000.0, -200000.0);
+        const BoundVec3 max_bound(200000.0, 200000.0, 200000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10e6;
+        const std::size_t num_radial_sections = 512;
+        const std::size_t num_angular_sections = 1;
+        const std::size_t num_azimuthal_sections = 1;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 3;
+        const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
+        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        std::vector<int> expected_radial_voxels(num_radial_sections * 2 - 1); // { 1, 2, .. N-1, N, N-1, .. 3, 2, 1 }
+        std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + num_radial_sections, 1);
+        std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + num_radial_sections - 1, 1);
+
+        std::vector<int> expected_theta_voxels(num_radial_sections * 2 - 1);
+        std::vector<int> expected_phi_voxels(num_radial_sections * 2 - 1);
+        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ... 1, 1 }
+        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ... 1, 1 }
+
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
     TEST(SphericalCoordinateTraversal, LargeNumberOfAngularSections) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
@@ -528,5 +613,53 @@ namespace {
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsInOutermostRadiusAndEndsWithinSphere) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
+        const FreeVec3 ray_direction(1.3, 1.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 4.3;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
+        const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
+        const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsAtSphereOrigin) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(0.0, 0.0, 0.0);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
+        const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
+        const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+
 
 } // namespace

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -79,7 +79,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, RayBeginsWithinSphereAndBeginTimeIsNotZero) {
+    TEST(SphericalCoordinateTraversal, RayBeginsWithinSphereAndTimeBeginIsNotZero) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -471,7 +471,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSections) {
+    TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSectionsOne) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
@@ -637,7 +637,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, TimeBeginsIsNotZero) {
+    TEST(SphericalCoordinateTraversal, TimeBeginIsNotZero) {
         const BoundVec3 min_bound(-20.0, -20.0, -20.0);
         const BoundVec3 max_bound(20.0, 20.0, 20.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -35,6 +35,54 @@ namespace {
         EXPECT_THAT(phi_voxels, testing::ContainerEq(expected_phi_voxels));
     }
 
+    TEST(SphericalCoordinateTraversal, TestRayBeginsWithinSphere) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-15.0, 15.0, 15.0);
+        const FreeVec3 ray_direction(1.6, -1.2, -1.3);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 8.7;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {3, 4, 4, 3, 3, 3, 2, 1};
+        const std::vector<int> expected_theta_voxels = {0, 0, 3, 3, 3, 3, 3, 3};
+        const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 3, 3, 3};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, TestRayEndsWithinSphere) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(13.0, -15.0, 16.0);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 10.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
+        const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
+        const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+
+
     TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
         const BoundVec3 min_bound(0.0, 0.0, 0.0);
         const BoundVec3 max_bound(30.0, 30.0, 30.0);


### PR DESCRIPTION
## Test cases:
- See: #144 for test cases. **(WIP)**
- Added a few more test cases for a large number of radial sections. If we use a large number of radial sections and a not-so-large sphere max radius, our algorithm breaks down. What "large" means still needs to be ironed out. This also addresses #145

## Benchmarks:
- Fixed the orthographic benchmark so that each ray travels the entirety of the sphere, i.e. ```radial_voxels = 1, 2, ... , N-1, N, N-1, ... , 2, 1```
- The original benchmarks were incorrect. Not all rays were going entirely through the sphere. I will add new benchmarks here soon, verifying the ray travels the entirety of the sphere.

## Algorithm:
- Fix issues for when t_begin != 0.0 - This has to do with the ray sphere vector used with certain calculations. The ray_sphere_vector at t = 0.0 must be used for everything except finding out which voxel the ray originates in.
- Addresses #127. 
- Re-add Knuth's version of FP comparison. Many times the algorithm would incorrectly end by saying two equal numbers were not equal (or vice versa). This will cause a slowdown unfortunately, so it may be good to look into options where floating point comparison is not needed. One thought is some form of memoization.
