### PR TITLE
Fix Tangential Hit Bug, Update sectored sphere implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project extends the [yt](https://yt-project.org/) open-source data analysis
 - [CMake 3.7 or later](https://cmake.org/)
 - C++11-standard-compliant compiler
 
-#### To run the benchmarks: 
+### To run the benchmarks: 
 1. Install CMake version 3.7 or higher (https://cmake.org/)
 2. Clone the repository and build the benchmarks:
 ```
@@ -46,18 +46,17 @@ cd .. && ./bin/benchmark_SVR
 
 const BoundVec3 sphere_center(0.0, 0.0, 0.0);
 const double sphere_max_radius = 10.0;
+const svr::SphereBound min_bound = { .radial=0.0, .polar=0.0, .azimuthal=0.0 };
+const svr::SphereBound max_bound = { .radial=sphere_max_radius, .polar=2*M_PI, .azimuthal=2*M_PI };
 const svr::SphericalVoxelGrid grid(min_bound, max_bound, 
                                    /*num_radial_sections=*/4, 
                                    /*num_polar_sections=*/4,
                                    /*num_azimuthal_sections=*/4, 
-                                   sphere_center, sphere_max_radius);
+                                   sphere_center);
 const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
 const FreeVec3 ray_direction(1.0, 1.0, 1.0);
 const Ray ray(ray_origin, ray_direction);
-const svr::SphereBound min_bound = { .radial=0.0, .polar=0.0, .azimuthal=0.0 };
-const svr::SphereBound max_bound = { .radial=sphere_max_radius, .polar=2*M_PI, .azimuthal=2*M_PI };
-const auto voxels = svr::walkSphericalVolume(ray, grid, min_bound, max_bound, 
-                                             /*t_begin=*/0.0, /*t_end=*/30.0);
+const auto voxels = svr::walkSphericalVolume(ray, grid, /*t_begin=*/0.0, /*t_end=*/30.0);
 ```
 
 ## Cython Build Requirements
@@ -76,25 +75,25 @@ import numpy as np
 
 ray_origin    = np.array([-13.0, -13.0, -13.0])
 ray_direction = np.array([1.0, 1.0, 1.0])
-min_bound     = np.array([-20.0, -20.0, -20.0])
-max_bound     = np.array([20.0, 20.0, 20.0])
 sphere_center = np.array([0.0, 0.0, 0.0])
 sphere_max_radius      = 10.0
 num_radial_sections    =  4
 num_polar_sections     =  4
 num_azimuthal_sections =  4
-t_begin = 0.0
-t_end =  30.0
+min_bound = np.array([0.0, 0.0, 0.0])
+max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+t_begin   = 0.0
+t_end     = 30.0
 voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, 
                                           num_radial_sections, num_polar_sections, 
-                                          num_azimuthal_sections, sphere_center,
-                                          sphere_max_radius, t_begin, t_end)
+                                          num_azimuthal_sections, sphere_center, t_begin, t_end)
 ```
 
 ### Project Links
 - [Initial Proposal](https://hackmd.io/VRyhXnAFQyaCytWCdKe_1Q)
 - [Feasibility Study](https://docs.google.com/document/d/1MbGmy5cSSesI0oUCWHxpiwcHEw6kqd79AV1XZW-rEZo/edit)
-- [Progress Report 1](https://docs.google.com/document/d/1ixD7XNu39kwwXhvQooMNb79x18-GsyMPLodzvwC3X-E/edit?ts=5e5d6f45#)
+- [Progress Report](https://docs.google.com/document/d/1ixD7XNu39kwwXhvQooMNb79x18-GsyMPLodzvwC3X-E/edit?ts=5e5d6f45#)
+- [Final Report](https://docs.google.com/document/d/1AHyUod23MtOnhCSbB4lvm5ZKAX3HhVL5KglLV-IlIlc/edit#heading=h.93f22ixpbzrf)
 
 ### References
 - John Amanatides and Andrew Woo. A fast voxel traversal algorithm for ray tracing. In Eurographics ’87, pages 3–10, 1987.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ t_end     = 30.0
 voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, 
                                           num_radial_sections, num_polar_sections, 
                                           num_azimuthal_sections, sphere_center, t_begin, t_end)
+
+# Expected voxels: [ [1, 2, 2], [2, 2, 2], [3, 2, 2], [4, 2, 2],
+#                    [4, 0, 0], [3, 0, 0], [2, 0, 0], [1, 0, 0] ]
 ```
 
 ### Project Links

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const auto voxels = svr::walkSphericalVolume(ray, grid, /*t_begin=*/0.0, /*t_end
 ### Cython Example
 ```
 #   Compile code before use:
-#   python cython_SVR_setup.py build_ext --inplace
+#   python3 cython_SVR_setup.py build_ext --inplace
 
 import cython_SVR
 import numpy as np

--- a/cpp/benchmarks/benchmark_SVR.cpp
+++ b/cpp/benchmarks/benchmark_SVR.cpp
@@ -35,8 +35,8 @@ namespace {
         const std::size_t num_azimuthal_sections = Y;
         const svr::SphereBound min_bound = {.radial=0.0, .polar=0.0, .azimuthal=0.0};
         const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=2 * M_PI, .azimuthal=2 * M_PI};
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = sphere_max_radius * 3;
 
@@ -49,8 +49,7 @@ namespace {
             for (std::size_t j = 0; j < X; ++j) {
                 const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
                 const FreeVec3  ray_direction(0.0, 0.0, 1.0);
-                const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
-                                                               min_bound, max_bound, t_begin, t_end);
+                const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
                 #if DEBUG
                 const std::size_t last = actual_voxels.size() - 1;
                 if (actual_voxels[0].radial_voxel != 1 || actual_voxels[last].radial_voxel != 1) {

--- a/cpp/benchmarks/benchmark_SVR.cpp
+++ b/cpp/benchmarks/benchmark_SVR.cpp
@@ -1,7 +1,7 @@
 #include <benchmark/benchmark.h>
 #include "../spherical_volume_rendering_util.h"
 
-# define DEBUG 0
+# define DEBUG 1
 
 // Benchmarking for the spherical coordinate voxel traversal algorithm.
 // Utilises the Google Benchmark library.

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -53,7 +53,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
           and max_bound = [SPHERE_MAX_RADIUS, 2*pi, 2*pi]. Similarly, if one wants to traverse
           the upper hemisphere, max_bound = SPHERE_MAX_RADIUS, 2*pi, pi].
         - Code must be compiled before use:
-           > python cython_SVR_setup.py build_ext --inplace
+           > python3 cython_SVR_setup.py build_ext --inplace
     '''
     assert(ray_origin.size == 3)
     assert(ray_direction.size == 3)

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -12,9 +12,9 @@ cdef extern from "../spherical_volume_rendering_util.h" namespace "svr":
         double radial, polar, azimuthal
 
     vector[SphericalVoxel] walkSphericalVolume(double *ray_origin, double *ray_direction,
+                                               double *min_bound, double *max_bound,
                                                size_t num_radial_voxels, size_t num_polar_voxels,
                                                size_t num_azimuthal_voxels, double *sphere_center,
-                                               double sphere_max_radius, double *min_bound, double *max_bound,
                                                double t_begin, double t_end)
 
 @cython.boundscheck(False)
@@ -22,11 +22,10 @@ cdef extern from "../spherical_volume_rendering_util.h" namespace "svr":
 @cython.cdivision(True)
 def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] ray_direction,
-                          int num_radial_voxels, int num_polar_voxels, int num_azimuthal_voxels,
-                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center,
-                          np.float64_t sphere_max_radius,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] min_bound,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] max_bound,
+                          int num_radial_voxels, int num_polar_voxels, int num_azimuthal_voxels,
+                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center,
                           np.float64_t t_begin, np.float64_t t_end):
     '''
     Spherical Coordinate Voxel Traversal Algorithm
@@ -34,13 +33,12 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
     Arguments:
            ray_origin: The 3-dimensional (x,y,z) origin of the ray.
            ray_direction: The 3-dimensional (x,y,z) direction of the ray.
+           min_bound: The minimum boundary of the sectored sphere in the form (radial, theta, phi).
+           max_bound: The maximum boundary of the sectored sphere in the form (radial, theta, phi).
            num_radial_voxels: The number of radial voxels.
            num_polar_voxels: The number of polar voxels.
            num_azimuthal_voxels: The number of azimuthal voxels.
            sphere_center: The 3-dimensional (x,y,z) center of the sphere.
-           min_bound: The minimum boundary of the sectored sphere in the form (radial, theta, phi).
-           max_bound: The maximum boundary of the sectored sphere in the form (radial, theta, phi).
-           sphere_max_radius: The maximum radius of the sphere.
            t_begin: The beginning time of the ray.
            t_end: The end time of the ray.
     Returns:
@@ -64,9 +62,9 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
     assert(max_bound.size == 3)
 
     cdef vector[SphericalVoxel] voxels = walkSphericalVolume(&ray_origin[0], &ray_direction[0],
+                                                             &min_bound[0], &max_bound[0],
                                                              num_radial_voxels, num_polar_voxels,
                                                              num_azimuthal_voxels, &sphere_center[0],
-                                                             sphere_max_radius, &min_bound[0], &max_bound[0],
                                                              t_begin, t_end)
     cdef np.ndarray cyVoxels = np.empty((voxels.size(), 3), dtype=int)
     for i in range(voxels.size()):

--- a/cpp/cython/cython_SVR_setup.py
+++ b/cpp/cython/cython_SVR_setup.py
@@ -7,7 +7,7 @@ Dependencies:
   3. distutils (https://docs.python.org/3/library/distutils.html)
 
 Code must be compiled before use:
-  > python cython_SVR_setup.py build_ext --inplace
+  > python3 cython_SVR_setup.py build_ext --inplace
 '''
 
 import numpy

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -1,7 +1,7 @@
 '''
 Testing for cythonized version of the spherical coordinate voxel traversal algorithm.
 To compile SVR code:
-    python cython_SVR_setup.py build_ext --inplace
+    python3 cython_SVR_setup.py build_ext --inplace
 '''
 
 import unittest

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -35,9 +35,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 15.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         assert voxels.size == 0
 
     def test_sphere_center_at_origin(self):
@@ -52,9 +52,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
@@ -72,9 +72,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [2,3,4,4,4,4,3,2,1]
         expected_theta_voxels = [1,1,1,0,3,3,3,3,3]
         expected_phi_voxels = [1,1,1,0,0,3,3,3,3]
@@ -92,9 +92,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [4,3,2,1]
         expected_theta_voxels = [3,3,3,3]
         expected_phi_voxels = [0,0,0,0]
@@ -112,9 +112,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 10.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 3]
         expected_theta_voxels = [3, 3, 2, 2]
         expected_phi_voxels = [0, 0, 1, 1]
@@ -132,9 +132,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 5.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [2,3,4,4,4]
         expected_theta_voxels = [1,1,1,0,3]
         expected_phi_voxels = [1,1,1,0,0]
@@ -152,9 +152,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 3, 2, 2, 1]
         expected_theta_voxels = [2, 2, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 2, 0, 0]
@@ -173,9 +173,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [3,3,3,3,0,0,0,0]
         expected_phi_voxels = [1,1,1,1,0,0,0,0]
@@ -193,9 +193,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [5,5,5,5,1,1,1,1]
         expected_phi_voxels = [0,0,0,0,0,0,0,0]
@@ -213,9 +213,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [0,0,0,0,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
@@ -233,9 +233,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,0,0,0,0]
         expected_phi_voxels = [1,1,1,1,0,0,0,0]
@@ -253,9 +253,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [1,1,1,1,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
@@ -273,9 +273,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
@@ -293,9 +293,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 0, 0, 3, 3, 3]
         expected_phi_voxels = [2, 2, 2, 1, 1, 0, 0, 0, 0, 0]
@@ -313,9 +313,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 1, 2, 2, 1]
         expected_theta_voxels = [2, 1, 1, 0, 0]
         expected_phi_voxels = [1, 1, 1, 0, 0]
@@ -333,9 +333,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
         expected_phi_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
@@ -353,9 +353,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 1, 2, 1, 1]
         expected_theta_voxels = [0, 3, 3, 3, 2]
         expected_phi_voxels = [0, 0, 0, 0, 1]
@@ -373,9 +373,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 1, 1, 0, 0]
@@ -393,9 +393,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
@@ -413,9 +413,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
                                   18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
                                   33, 34, 35, 36, 37, 38, 39, 40, 40, 39, 38, 37, 36, 35, 34,
@@ -443,9 +443,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -463,9 +463,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
@@ -483,9 +483,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 50.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
         expected_phi_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
@@ -503,9 +503,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 4.3
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4]
         expected_theta_voxels = [2, 2, 2, 3, 3, 0]
         expected_phi_voxels = [2, 2, 2, 3, 3, 3]
@@ -523,9 +523,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [2, 2, 2, 2]
@@ -543,9 +543,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [2, 2, 2, 2]
@@ -563,9 +563,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 1, 2, 2, 2]
@@ -583,9 +583,9 @@ class TestWalkSphericalVolume(unittest.TestCase):
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 2, 2]
@@ -598,14 +598,14 @@ class TestWalkSphericalVolume(unittest.TestCase):
         sphere_max_radius = 10.0
         num_radial_sections = 4
         num_polar_sections = 8
-        num_azimuthal_sections = 8
+        num_azimuthal_sections = 4
         t_begin = 0.0
         t_end = 35.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0]
         expected_phi_voxels = [3, 3, 3, 3, 3, 2, 1, 0, 0, 0, 0, 0]
@@ -618,14 +618,14 @@ class TestWalkSphericalVolume(unittest.TestCase):
         sphere_max_radius = 10.0
         num_radial_sections = 4
         num_polar_sections = 8
-        num_azimuthal_sections = 8
+        num_azimuthal_sections = 4
         t_begin = 0.0
         t_end = 35.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, num_radial_sections,
-                                                  num_polar_sections, num_azimuthal_sections, sphere_center,
-                                                  sphere_max_radius, min_bound, max_bound, t_begin, t_end)
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
         assert voxels.size == 0
 
 if __name__ == '__main__':

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -537,8 +537,8 @@ class TestWalkSphericalVolume(unittest.TestCase):
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
-        num_polar_sections = 1
-        num_azimuthal_sections = 1
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
         t_begin = 0.0
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])
@@ -571,14 +571,14 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [1, 1, 1, 2, 2, 2]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
-    def test_ray_tangential_hit_two(self):
+    def test_num_angular_sections_is_one(self):
         ray_origin = np.array([-2.5, 0.0, 10.0])
         ray_direction = np.array([0.0, 0.0, -1.0])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
-        num_polar_sections = 4
-        num_azimuthal_sections = 4
+        num_polar_sections = 1
+        num_azimuthal_sections = 1
         t_begin = 0.0
         t_end = 30.0
         min_bound = np.array([0.0, 0.0, 0.0])

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -548,7 +548,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
                                                   sphere_center, t_begin, t_end)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
-        expected_phi_voxels = [2, 2, 2, 2]
+        expected_phi_voxels = [1, 1, 2, 2]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_tangential_hit_two(self):
@@ -569,6 +569,26 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_radial_voxels = [1, 2, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 1, 2, 2, 2]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_tangential_hit_two(self):
+        ray_origin = np.array([-2.5, 0.0, 10.0])
+        ray_direction = np.array([0.0, 0.0, -1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [1, 2, 3, 3, 2, 1]
+        expected_theta_voxels = [0, 0, 0, 0, 0, 0]
+        expected_phi_voxels = [0, 0, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_nearly_tangential_hit(self):

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -275,20 +275,20 @@ namespace svr {
                              (!is_tangential_hit && !is_radial_transition
                               && lessThan(r_new, current_radius))],
                 .previous_transition_flag=is_radial_transition,
-                .within_bounds=lessThan(t, intersection_time) && lessThan(intersection_time, t_end) };
+                .within_bounds=lessThan(t, intersection_time) && lessThan(intersection_time, t_end)
+        };
     }
 
     // A generalized version of the latter half of the polar and azimuthal hit parameters. Since the only difference
-    // is the 2-d plane for which they exist in, this portion can be generalized to a single function call.
+    // is the 2-d plane for which they exist in, this portion can be generalized to a single function.
     // The calculations presented below follow closely the works of [Foley et al, 1996], [O'Rourke, 1998].
     // Reference: http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
-
-    AngularHitParameters
-    angularHit(const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min, double perp_uv_max,
-               double perp_uw_min, double perp_uw_max, double perp_vw_min, double perp_vw_max,
-               const RaySegment &RS, const std::array<double, 2> &collinear_times, double t, double t_end,
-               double ray_direction_2, double sphere_center_2,
-               const std::vector<svr::LineSegment> &P_max, int current_voxel_ID) noexcept {
+    AngularHitParameters angularHit(const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min,
+                                    double perp_uv_max, double perp_uw_min, double perp_uw_max, double perp_vw_min,
+                                    double perp_vw_max, const RaySegment &RS,
+                                    const std::array<double, 2> &collinear_times, double t, double t_end,
+                                    double ray_direction_2, double sphere_center_2,
+                                    const std::vector<svr::LineSegment> &P_max, int current_voxel_ID) noexcept {
         const bool is_parallel_min = isEqual(perp_uv_min, 0.0);
         const bool is_collinear_min = is_parallel_min && isEqual(perp_uw_min, 0.0) && isEqual(perp_vw_min, 0.0);
         const bool is_parallel_max = isEqual(perp_uv_max, 0.0);
@@ -367,8 +367,8 @@ namespace svr {
                              grid.pMaxPolar(current_voxel_ID_theta).P2, 0.0);
         const FreeVec3 p_two(grid.pMaxPolar(current_voxel_ID_theta + 1).P1,
                              grid.pMaxPolar(current_voxel_ID_theta + 1).P2, 0.0);
-        const BoundVec3 u_min = grid.sphereCenter() - p_one;
-        const BoundVec3 u_max = grid.sphereCenter() - p_two;
+        const BoundVec3 u_min(grid.centerToPolarBound(current_voxel_ID_theta));
+        const BoundVec3 u_max(grid.centerToPolarBound(current_voxel_ID_theta + 1));
         const FreeVec3 w_min = p_one - FreeVec3(RS.P1());
         const FreeVec3 w_max = p_two - FreeVec3(RS.P1());
         const double perp_uv_min = u_min.x() * RS.raySegment().y() - u_min.y() * RS.raySegment().x();
@@ -396,8 +396,8 @@ namespace svr {
                              grid.pMaxAzimuthal(current_voxel_ID_phi).P2);
         const FreeVec3 p_two(grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P1, 0.0,
                              grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P2);
-        const BoundVec3 u_min = grid.sphereCenter() - p_one;
-        const BoundVec3 u_max = grid.sphereCenter() - p_two;
+        const BoundVec3 u_min(grid.centerToAzimuthalBound(current_voxel_ID_phi));
+        const BoundVec3 u_max(grid.centerToAzimuthalBound(current_voxel_ID_phi + 1));
         const FreeVec3 w_min = p_one - FreeVec3(RS.P1());
         const FreeVec3 w_max = p_two - FreeVec3(RS.P1());
         const double perp_uv_min = u_min.x() * RS.raySegment().z() - u_min.z() * RS.raySegment().x();
@@ -498,8 +498,6 @@ namespace svr {
     }
 
     std::vector<svr::SphericalVoxel> walkSphericalVolume(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                                         const svr::SphereBound &min_bound,
-                                                         const svr::SphereBound &max_bound,
                                                          double t_begin, double t_end) noexcept {
         const FreeVec3 rsv = grid.sphereCenter() - ray.pointAtParameter(t_begin);   // Ray Sphere Vector.
         const FreeVec3 rsv_tz = (t_begin == 0.0) ? rsv : grid.sphereCenter() - ray.pointAtParameter(0.0);
@@ -531,9 +529,6 @@ namespace svr {
 
         if ((t_entrance < t_begin && t_exit < t_begin) || isEqual(t_entrance, t_exit)) { return {}; }
         int current_voxel_ID_r = idx + 1;
-        const int min_radial_ID = std::max(min_bound.radial * grid.invDeltaRadius(), 1.0);
-        const int max_radial_ID = max_bound.radial * grid.invDeltaRadius();
-        if (current_voxel_ID_r < min_radial_ID) { return {}; }
 
         std::vector<svr::LineSegment> P_polar(grid.numPolarVoxels() + 1);
         std::vector<svr::LineSegment> P_azimuthal(grid.numAzimuthalVoxels() + 1);
@@ -546,15 +541,11 @@ namespace svr {
 
         int current_voxel_ID_theta = initializeAngularVoxelID(grid, ray_sphere, P_polar, ray_sphere.y(),
                                                               grid.sphereCenter().y(), entry_radius);
-        const int min_polar_ID = min_bound.polar * grid.invDeltaTheta();
-        const int max_polar_ID = max_bound.polar * grid.invDeltaTheta();
-        if (current_voxel_ID_theta < min_polar_ID || current_voxel_ID_theta >= max_polar_ID) { return {}; }
+        if (current_voxel_ID_theta == grid.numPolarVoxels()) { return {}; }
 
         int current_voxel_ID_phi = initializeAngularVoxelID(grid, ray_sphere, P_azimuthal, ray_sphere.z(),
                                                            grid.sphereCenter().z(), entry_radius);
-        const int min_azimuthal_ID = min_bound.azimuthal * grid.invDeltaPhi();
-        const int max_azimuthal_ID = max_bound.azimuthal * grid.invDeltaPhi();
-        if (current_voxel_ID_phi < min_azimuthal_ID || current_voxel_ID_phi >= max_azimuthal_ID) { return {}; }
+        if (current_voxel_ID_phi == grid.numAzimuthalVoxels()) { return {}; }
 
         std::vector<svr::SphericalVoxel> voxels;
         voxels.reserve(grid.numRadialVoxels() + grid.numPolarVoxels() + grid.numAzimuthalVoxels());
@@ -639,11 +630,6 @@ namespace svr {
                     return voxels;
                 }
             }
-            if (current_voxel_ID_r > max_radial_ID ||
-                current_voxel_ID_theta >= max_polar_ID ||
-                current_voxel_ID_phi >= max_azimuthal_ID) {
-                return voxels;
-            }
             voxels.push_back({.radial_voxel=current_voxel_ID_r,
                               .polar_voxel=current_voxel_ID_theta,
                               .azimuthal_voxel=current_voxel_ID_phi});
@@ -651,26 +637,27 @@ namespace svr {
     }
 
     std::vector<svr::SphericalVoxel> walkSphericalVolume(double *ray_origin, double *ray_direction,
+                                                         double* min_bound, double* max_bound,
                                                          std::size_t num_radial_voxels,
                                                          std::size_t num_polar_voxels,
                                                          std::size_t num_azimuthal_voxels,
-                                                         double *sphere_center, double sphere_max_radius,
-                                                         double *min_bound, double* max_bound,
-                                                         double t_begin, double t_end) noexcept {
+                                                         double *sphere_center, double t_begin, double t_end) noexcept {
         return svr::walkSphericalVolume(Ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
-                                            FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2])),
-                                        svr::SphericalVoxelGrid(num_radial_voxels,
+                                            FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2])
+                                        ),
+                                        svr::SphericalVoxelGrid(svr::SphereBound{.radial=min_bound[0],
+                                                                                 .polar=min_bound[1],
+                                                                                 .azimuthal=min_bound[2]},
+                                                                svr::SphereBound{.radial=max_bound[0],
+                                                                                 .polar=max_bound[1],
+                                                                                 .azimuthal=max_bound[2]},
+                                                                num_radial_voxels,
                                                                 num_polar_voxels,
                                                                 num_azimuthal_voxels,
-                                                                BoundVec3(sphere_center[0], sphere_center[1],
-                                                                          sphere_center[2]), sphere_max_radius),
-                                        svr::SphereBound{.radial=min_bound[0],
-                                                         .polar=min_bound[1],
-                                                         .azimuthal=min_bound[2]},
-                                        svr::SphereBound{.radial=max_bound[0],
-                                                         .polar=max_bound[1],
-                                                         .azimuthal=max_bound[2]},
-                                        t_begin, t_end);
+                                                                BoundVec3(sphere_center[0],
+                                                                          sphere_center[1],
+                                                                          sphere_center[2])
+                                        ), t_begin, t_end);
     }
 
 } // namespace svr

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -282,7 +282,7 @@ namespace svr {
         const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
         const bool is_radial_transition = isEqual(r_new, current_radius);
         return {.tMaxR=intersection_time,
-                .tStepR=STEP[!is_radial_transition && lessThan(r_new, current_radius)],
+                .tStepR=STEP[!is_radial_transition && r_new < current_radius],
                 .previous_transition_flag=is_radial_transition,
                 .within_bounds=true
         };
@@ -405,14 +405,14 @@ namespace svr {
                              grid.pMaxAzimuthal(current_voxel_ID_phi).P2);
         const FreeVec3 p_two(grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P1, 0.0,
                              grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P2);
-        const BoundVec3 u_min(grid.centerToAzimuthalBound(current_voxel_ID_phi));
-        const BoundVec3 u_max(grid.centerToAzimuthalBound(current_voxel_ID_phi + 1));
+        const BoundVec3 *u_min = &grid.centerToAzimuthalBound(current_voxel_ID_phi);
+        const BoundVec3 *u_max = &grid.centerToAzimuthalBound(current_voxel_ID_phi + 1);
         const FreeVec3 w_min = p_one - FreeVec3(RS.P1());
         const FreeVec3 w_max = p_two - FreeVec3(RS.P1());
-        const double perp_uv_min = u_min.x() * RS.raySegment().z() - u_min.z() * RS.raySegment().x();
-        const double perp_uv_max = u_max.x() * RS.raySegment().z() - u_max.z() * RS.raySegment().x();
-        const double perp_uw_min = u_min.x() * w_min.z() - u_min.z() * w_min.x();
-        const double perp_uw_max = u_max.x() * w_max.z() - u_max.z() * w_max.x();
+        const double perp_uv_min = u_min->x() * RS.raySegment().z() - u_min->z() * RS.raySegment().x();
+        const double perp_uv_max = u_max->x() * RS.raySegment().z() - u_max->z() * RS.raySegment().x();
+        const double perp_uw_min = u_min->x() * w_min.z() - u_min->z() * w_min.x();
+        const double perp_uw_max = u_max->x() * w_max.z() - u_max->z() * w_max.x();
         const double perp_vw_min = RS.raySegment().x() * w_min.z() - RS.raySegment().z() * w_min.x();
         const double perp_vw_max = RS.raySegment().x() * w_max.z() - RS.raySegment().z() * w_max.x();
         const AngularHitParameters params = angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -550,11 +550,11 @@ namespace svr {
 
         int current_voxel_ID_theta = initializeAngularVoxelID(grid, grid.numPolarVoxels(), ray_sphere, P_polar,
                                                               ray_sphere.y(), grid.sphereCenter().y(), entry_radius);
-        if (current_voxel_ID_theta == grid.numPolarVoxels()) { return {}; }
+        if (static_cast<std::size_t>(current_voxel_ID_theta) == grid.numPolarVoxels()) { return {}; }
 
         int current_voxel_ID_phi = initializeAngularVoxelID(grid, grid.numAzimuthalVoxels(), ray_sphere, P_azimuthal,
                                                             ray_sphere.z(), grid.sphereCenter().z(), entry_radius);
-        if (current_voxel_ID_phi == grid.numAzimuthalVoxels()) { return {}; }
+        if (static_cast<std::size_t>(current_voxel_ID_phi) == grid.numAzimuthalVoxels()) { return {}; }
 
         std::vector<svr::SphericalVoxel> voxels;
         voxels.reserve(grid.numRadialVoxels() + grid.numPolarVoxels() + grid.numAzimuthalVoxels());

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -263,21 +263,19 @@ namespace svr {
             intersection_times[3] = ray.timeOfIntersectionAt(rh_data.v() + d_b);
         }
 
-        const auto intersection_time_it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
+        const auto it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
                                                        [t](double i)->double{ return i > t; });
-        if (intersection_time_it == intersection_times.cend()) {
+        if (it == intersection_times.cend() || (t >= *it) || (*it >= t_end)) {
             return {.tMaxR=std::numeric_limits<double>::max(), .tStepR=0,
                     .previous_transition_flag=false, .within_bounds=false };
         }
 
-        const double intersection_time = *intersection_time_it;
-        const bool is_tangential_hit = intersection_times[0] > t && isEqual(intersection_times[0], intersection_times[1]);
-        const bool within_t_bounds = lessThan(t, intersection_time) && lessThan(intersection_time, t_end);
-        if (is_tangential_hit) {
+        const double intersection_time = *it;
+        if (intersection_times[0] > t && isEqual(intersection_times[0], intersection_times[1])) {
             return {.tMaxR=intersection_time,
                     .tStepR=0,
                     .previous_transition_flag=true,
-                    .within_bounds=within_t_bounds
+                    .within_bounds=true
             };
         }
 
@@ -286,7 +284,7 @@ namespace svr {
         return {.tMaxR=intersection_time,
                 .tStepR=STEP[!is_radial_transition && lessThan(r_new, current_radius)],
                 .previous_transition_flag=is_radial_transition,
-                .within_bounds=within_t_bounds
+                .within_bounds=true
         };
     }
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -15,36 +15,19 @@ namespace svr {
         int azimuthal_voxel;
     };
 
-    // Represents the boundary for the sphere. This is used to determine the minimum and maximum
-    // boundaries for a sectored traversal.
-    struct SphereBound {
-        double radial;
-        double polar;
-        double azimuthal;
-    };
-
     // A spherical coordinate voxel traversal algorithm. The algorithm traces the ray over the spherical voxel grid
     // provided. t_begin is the time the ray begins, and t_end is the time at which the ray ends. It does not
     // assumes the ray direction is normalized. Returns a vector of the spherical coordinate voxels traversed.
-    // The sphere bounds are used to determine the sector of the sphere to be traversed.
-    // For example, if one wants to traverse the entire sphere, then:
-    // SphereBound min_bound = { .radial=0.0, .polar=0.0, .azimuthal=0.0 }
-    // SphereBound max_bound = { .radial=SPHERE_MAX_RADIUS, .polar=2 * M_PI, .azimuthal=2 * M_PI }
-    // If instead one wants to traverse the upper hemisphere, then:
-    // SphereBound max_bound = { .radial=SPHERE_MAX_RADIUS, .polar=2*M_PI, .azimuthal=M_PI }
     std::vector<SphericalVoxel> walkSphericalVolume(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                                    const svr::SphereBound &min_bound,
-                                                    const svr::SphereBound &max_bound,
                                                     double t_begin, double t_end) noexcept;
 
     // Simplified parameters to Cythonize the function; implementation remains the same as above.
     std::vector<SphericalVoxel> walkSphericalVolume(double *ray_origin, double *ray_direction,
+                                                    double *min_bound, double *max_bound,
                                                     std::size_t num_radial_voxels,
                                                     std::size_t num_polar_voxels,
                                                     std::size_t num_azimuthal_voxels,
-                                                    double *sphere_center, double sphere_max_radius,
-                                                    double *min_bound, double *max_bound,
-                                                    double t_begin, double t_end) noexcept;
+                                                    double *sphere_center, double t_begin, double t_end) noexcept;
 
 } // namespace svr
 

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -45,10 +45,7 @@ namespace svr {
                 sphere_max_radius_(max_bound.radial),
                 delta_radius_((max_bound.radial - min_bound.radial) / num_radial_voxels),
                 delta_theta_((max_bound.polar - min_bound.polar) / num_polar_voxels),
-                delta_phi_((max_bound.azimuthal - min_bound.azimuthal) / num_azimuthal_voxels),
-                inverse_delta_radius_(1.0 / delta_radius_),
-                inverse_delta_theta_(1.0 / delta_theta_),
-                inverse_delta_phi_(1.0 / delta_phi_) {
+                delta_phi_((max_bound.azimuthal - min_bound.azimuthal) / num_azimuthal_voxels) {
 
             delta_radii_.resize(num_radial_voxels + 1);
             double current_delta_radius = delta_radius_ * num_radial_voxels;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -29,14 +29,10 @@ namespace svr {
     };
 
 
-    // todo: Add bounds to the grid.
-    // todo: Documentation
-    // The sphere bounds are used to determine the sector of the sphere to be traversed.
-    // For example, if one wants to traverse the entire sphere, then:
-    // SphereBound min_bound = { .radial=0.0, .polar=0.0, .azimuthal=0.0 }
-    // SphereBound max_bound = { .radial=SPHERE_MAX_RADIUS, .polar=2 * M_PI, .azimuthal=2 * M_PI }
-    // If instead one wants to traverse the upper hemisphere, then:
-    // SphereBound max_bound = { .radial=SPHERE_MAX_RADIUS, .polar=2*M_PI, .azimuthal=M_PI }
+    // Represents a spherical voxel grid used for ray casting. The bounds of the grid are determined by min_bound
+    // and max_bound. The deltas are then determined by (max_bound.X - min_bound.X) / num_X_sections. To minimize
+    // calculation duplication, many calculations are completed once here and used each time a ray traverses the
+    // spherical voxel grid.
     struct SphericalVoxelGrid {
     public:
         SphericalVoxelGrid(const SphereBound &min_bound, const SphereBound &max_bound,

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -135,12 +135,6 @@ namespace svr {
 
         inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
-        inline double invDeltaRadius() const noexcept { return this->inverse_delta_radius_; }
-
-        inline double invDeltaTheta() const noexcept { return this->inverse_delta_theta_; }
-
-        inline double invDeltaPhi() const noexcept { return this->inverse_delta_phi_; }
-
         inline const BoundVec3 &sphereCenter() const noexcept { return this->sphere_center_; }
 
         inline double deltaRadii(std::size_t i) const noexcept { return this->delta_radii_[i]; }

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -36,36 +36,36 @@ namespace svr {
     struct SphericalVoxelGrid {
     public:
         SphericalVoxelGrid(const SphereBound &min_bound, const SphereBound &max_bound,
-                std::size_t num_radial_voxels, std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
-                const BoundVec3 &sphere_center) :
-                num_radial_voxels_(num_radial_voxels),
-                num_polar_voxels_(num_polar_voxels),
-                num_azimuthal_voxels_(num_azimuthal_voxels),
+                           std::size_t num_radial_sections, std::size_t num_polar_sections,
+                           std::size_t num_azimuthal_sections, const BoundVec3 &sphere_center) :
+                num_radial_sections_(num_radial_sections),
+                num_polar_sections_(num_polar_sections),
+                num_azimuthal_sections_(num_azimuthal_sections),
                 sphere_center_(sphere_center),
                 sphere_max_radius_(max_bound.radial),
-                delta_radius_((max_bound.radial - min_bound.radial) / num_radial_voxels),
-                delta_theta_((max_bound.polar - min_bound.polar) / num_polar_voxels),
-                delta_phi_((max_bound.azimuthal - min_bound.azimuthal) / num_azimuthal_voxels) {
+                delta_radius_((max_bound.radial - min_bound.radial) / num_radial_sections),
+                delta_theta_((max_bound.polar - min_bound.polar) / num_polar_sections),
+                delta_phi_((max_bound.azimuthal - min_bound.azimuthal) / num_azimuthal_sections) {
 
-            delta_radii_.resize(num_radial_voxels + 1);
-            double current_delta_radius = delta_radius_ * num_radial_voxels;
+            delta_radii_.resize(num_radial_sections + 1);
+            double current_delta_radius = delta_radius_ * num_radial_sections;
             std::generate(delta_radii_.begin(), delta_radii_.end(),
                           [&]() -> double {
                               const double old_delta_radius = current_delta_radius;
                               current_delta_radius -= delta_radius_;
                               return old_delta_radius;
                           });
-            delta_radii_sq_.resize(num_radial_voxels + 1);
+            delta_radii_sq_.resize(num_radial_sections + 1);
             std::transform(delta_radii_.cbegin(), delta_radii_.cend(), delta_radii_sq_.begin(),
                            [](double dR) -> double { return dR * dR; });
 
-            P_max_polar_.resize(num_polar_voxels + 1);
-            P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
-            center_to_polar_bound_vectors_.reserve(num_polar_voxels + 1);
-            center_to_azimuthal_bound_vectors_.reserve(num_azimuthal_voxels + 1);
-            if (num_polar_voxels == num_azimuthal_voxels) {
+            P_max_polar_.resize(num_polar_sections + 1);
+            P_max_azimuthal_.resize(num_azimuthal_sections + 1);
+            center_to_polar_bound_vectors_.reserve(num_polar_sections + 1);
+            center_to_azimuthal_bound_vectors_.reserve(num_azimuthal_sections + 1);
+            if (num_polar_sections == num_azimuthal_sections) {
                 double radians = 0.0;
-                polar_trig_values_.resize(num_polar_voxels + 1);
+                polar_trig_values_.resize(num_polar_sections + 1);
                 std::generate(polar_trig_values_.begin(), polar_trig_values_.end(),
                               [&]() -> TrigonometricValues {
                                   const double cos = std::cos(radians);
@@ -91,7 +91,7 @@ namespace svr {
             }
 
             double radians = 0.0;
-            polar_trig_values_.resize(num_polar_voxels + 1);
+            polar_trig_values_.resize(num_polar_sections + 1);
             std::generate(polar_trig_values_.begin(), polar_trig_values_.end(), [&]() -> TrigonometricValues {
                 const double cos = std::cos(radians);
                 const double sin = std::sin(radians);
@@ -99,7 +99,7 @@ namespace svr {
                 return {.cosine=cos, .sine=sin};
             });
             radians = 0.0;
-            azimuthal_trig_values_.resize(num_azimuthal_voxels + 1);
+            azimuthal_trig_values_.resize(num_azimuthal_sections + 1);
             std::generate(azimuthal_trig_values_.begin(), azimuthal_trig_values_.end(), [&]() -> TrigonometricValues {
                 const double cos = std::cos(radians);
                 const double sin = std::sin(radians);
@@ -124,11 +124,11 @@ namespace svr {
             }
         }
 
-        inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
+        inline std::size_t numRadialSections() const noexcept { return this->num_radial_sections_; }
 
-        inline std::size_t numPolarVoxels() const noexcept { return this->num_polar_voxels_; }
+        inline std::size_t numPolarSections() const noexcept { return this->num_polar_sections_; }
 
-        inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
+        inline std::size_t numAzimuthalSections() const noexcept { return this->num_azimuthal_sections_; }
 
         inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
@@ -163,7 +163,7 @@ namespace svr {
 
     private:
         // The number of radial, polar, and azimuthal voxels.
-        const std::size_t num_radial_voxels_, num_polar_voxels_, num_azimuthal_voxels_;
+        const std::size_t num_radial_sections_, num_polar_sections_, num_azimuthal_sections_;
 
         // The center of the sphere.
         const BoundVec3 sphere_center_;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -180,9 +180,6 @@ namespace svr {
         // 2 * PI divided by X, where X is the number of polar and number of azimuthal sections respectively.
         const double delta_theta_, delta_phi_;
 
-        // The inverse of the deltas.
-        const double inverse_delta_radius_, inverse_delta_theta_, inverse_delta_phi_;
-
         // The delta radii ranging from 0...num_radial_voxels.
         std::vector<double> delta_radii_;
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ set(TESTING_SOURCE_FILES ../spherical_volume_rendering_util.cpp test_SVR.cpp)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 add_executable(${TESTING_BINARY} ${TESTING_SOURCE_FILES})
 target_link_libraries(${TESTING_BINARY} gtest_main gmock_main)
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "cpp/-Wall -Wextra")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -Wextra")
 
 enable_testing()
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TESTING_SOURCE_FILES ../spherical_volume_rendering_util.cpp test_SVR.cpp)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 add_executable(${TESTING_BINARY} ${TESTING_SOURCE_FILES})
 target_link_libraries(${TESTING_BINARY} gtest_main gmock_main)
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "cpp/-Wall -Wextra")
 
 enable_testing()
 

--- a/cpp/tests/test_SVR.cpp
+++ b/cpp/tests/test_SVR.cpp
@@ -45,16 +45,16 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(3.0, 3.0, 3.0);
         const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
         const Ray ray(ray_origin, ray_direction);
 
         const double t_begin = 0.0;
         const double t_end = 15.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         EXPECT_EQ(actual_voxels.size(), 0);
     }
 
@@ -64,15 +64,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
         const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3, 3, 3, 3, 3};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0, 3, 3, 3, 3};
@@ -85,15 +85,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
         const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 5.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {3, 3, 3, 3};
         const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
@@ -106,15 +106,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(13.0, -15.0, 16.0);
         const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 10.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
         const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
         const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
@@ -127,15 +127,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
         const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 5.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -148,15 +148,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -169,15 +169,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
         const FreeVec3 ray_direction(1.0, 1.5, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 1, 1, 1, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 2, 0, 0};
@@ -190,15 +190,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
         const FreeVec3 ray_direction(1.0, 0.0, 0.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {3, 3, 3, 3, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -211,15 +211,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(0.0, -15.0, 0.0);
         const FreeVec3 ray_direction(0.0, 1.0, 0.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {5, 5, 5, 5, 1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -232,15 +232,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(0.0, 0.0, -15.0);
         const FreeVec3 ray_direction(0.0, 0.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -253,15 +253,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
         const FreeVec3 ray_direction(1.0, 1.0, 0.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -274,15 +274,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
         const FreeVec3 ray_direction(1.0, 0.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -295,15 +295,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(0.0, -15.0, -15.0);
         const FreeVec3 ray_direction(0.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -316,15 +316,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(13.0, -15.0, -15.0);
         const FreeVec3 ray_direction(-1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
@@ -337,15 +337,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
         const FreeVec3 ray_direction(1.0, -1.2, 1.3);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 3, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 0, 0, 3, 3, 3};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 1, 1, 0, 0, 0, 0, 0};
@@ -358,15 +358,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
         const FreeVec3 ray_direction(1.4, 2.0, -1.3);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 1, 2, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 1, 1, 0, 0};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -379,15 +379,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(15.0, 12.0, 15.0);
         const FreeVec3 ray_direction(-1.4, -2.0, -1.3);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 1, 2, 1, 1};
         const std::vector<int> expected_theta_voxels = {0, 3, 3, 3, 2};
         const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 1};
@@ -400,15 +400,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 3;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.3);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 1, 1, 0, 0};
@@ -421,15 +421,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 3;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -442,15 +442,15 @@ namespace {
         const std::size_t num_radial_sections = 40;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
                                                          17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
                                                          31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 40, 39, 38, 37,
@@ -476,15 +476,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 40;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -497,15 +497,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 40;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
         const FreeVec3 ray_direction(1.0, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
@@ -518,15 +518,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-15.0, 15.0, 15.0);
         const FreeVec3 ray_direction(1.0, -1.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.01;
         const double t_end = 50.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
@@ -539,15 +539,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
         const FreeVec3 ray_direction(1.3, 1.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 4.3;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
         const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};
@@ -560,15 +560,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(0.0, 0.0, 0.0);
         const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
@@ -581,15 +581,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-5.0, 0.0, 10.0);
         const FreeVec3 ray_direction(0.0, 0.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
@@ -602,15 +602,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
         const FreeVec3 ray_direction(0.0, 0.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 2, 2, 2};
@@ -623,15 +623,15 @@ namespace {
         const std::size_t num_radial_sections = 128;
         const std::size_t num_polar_sections = 1;
         const std::size_t num_azimuthal_sections = 1;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = sphere_max_radius * 3;
         const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
         const FreeVec3 ray_direction(0.0, 0.0, 1.0);
         const Ray ray(ray_origin, ray_direction);
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         // TODO: Fix expected values.
         std::vector<int> expected_radial_voxels(119 * 2 - 1);
         std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + 119, 1);
@@ -651,15 +651,15 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const BoundVec3 ray_origin(-5.01, 0.0, 10.0);
         const FreeVec3 ray_direction(0.0, 0.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
-        const auto actual_voxels = walkSphericalVolume(ray, grid, MIN_BOUND, max_bound, t_begin, t_end);
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
         const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -671,14 +671,14 @@ namespace {
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
-        const std::size_t num_azimuthal_sections = 8;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=M_PI};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = 35.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=M_PI};
         const auto actual_voxels = walkSphericalVolume(Ray(BoundVec3(-11.0, 2.0, 1.0), FreeVec3(1.0, 0.0, 0.0)),
-                                                       grid, MIN_BOUND, max_bound, t_begin, t_end);
+                                                       grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 4, 4, 3, 3, 2, 1};
         const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {3, 3, 3, 3, 3, 2, 1, 0, 0, 0, 0, 0};
@@ -691,8 +691,7 @@ namespace {
                                                     BoundVec3(-1.0, -5.0, 20.0)};
         for (const auto& ray_origin : ray_origins) {
             const FreeVec3 ray_direction(0.0, 0.0, -1.0);
-            const auto v = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
-                                               MIN_BOUND, max_bound, t_begin, t_end);
+            const auto v = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
             EXPECT_NE(v.size(), 0);
         }
     }
@@ -702,58 +701,50 @@ namespace {
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 8;
-        const std::size_t num_azimuthal_sections = 8;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=M_PI};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = 35.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=M_PI};
-        const std::vector<BoundVec3> ray_origins = {BoundVec3(-5.0, -5.0, -5.0),
-                                                    BoundVec3(-1.0, -1.0, -1.0),
-                                                    BoundVec3(-15.0, -15.0, -15.0),
-                                                    BoundVec3(-15.0, -1.0, -1.0),
-                                                    BoundVec3(-1.0, -15.0, -1.0),
-                                                    BoundVec3(-1.0, -1.0, -15.0)};
-        for (const auto& ray_origin : ray_origins) {
-            const FreeVec3 ray_direction(1.0, 0.0, 0.0);
-            const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
-                                                               MIN_BOUND, max_bound, t_begin, t_end);
-            EXPECT_EQ(actual_voxels.size(), 0);
-        }
+        const BoundVec3 ray_origin = BoundVec3(-5.0, -5.0, -5.0);
+        const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+        const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+        EXPECT_EQ(actual_voxels.size(), 0);
     }
 
-    TEST(SphericalCoordinateTraversal, FirstQuadrantHit) {
+    TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
-        const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const std::size_t num_azimuthal_sections = 8;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=M_PI/2.0, .azimuthal=M_PI/2.0};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=M_PI/2.0, .azimuthal=M_PI/2.0};
         const auto actual_voxels = walkSphericalVolume(Ray(BoundVec3(13.0, 13.0, 13.0), FreeVec3(-1.0, -1.0, -1.0)),
-                                                       grid, MIN_BOUND, max_bound, t_begin, t_end);
+                                                       grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 3, 4};
         const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
         const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, FirstQuadrantMiss) {
+    TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 4;
-        const std::size_t num_azimuthal_sections = 4;
-        const svr::SphericalVoxelGrid grid(num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                           sphere_center, sphere_max_radius);
+        const std::size_t num_azimuthal_sections = 8;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=M_PI/2.0, .azimuthal=M_PI/2.0};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
         const double t_begin = 0.0;
         const double t_end = 30.0;
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=M_PI/2.0, .azimuthal=M_PI/2.0};
         const auto actual_voxels = walkSphericalVolume(Ray(BoundVec3(13.0, -13.0, 13.0), FreeVec3(-1.0, 1.0, -1.0)),
-                                                       grid, MIN_BOUND, max_bound, t_begin, t_end);
+                                                       grid, t_begin, t_end);
         EXPECT_EQ(actual_voxels.size(), 0);
     }
 

--- a/cpp/tests/test_SVR.cpp
+++ b/cpp/tests/test_SVR.cpp
@@ -575,7 +575,7 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(DISABLED_SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
+    TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
@@ -592,11 +592,11 @@ namespace {
         const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
         const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
-        const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
+        const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(DISABLED_SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelTwo) {
+    TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelTwo) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
@@ -617,31 +617,24 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(DISABLED_SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelThree) {
+    TEST(SphericalCoordinateTraversal, NumberOfAngularAndAzimuthalSectionsEqualsOne) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10e3;
-        const std::size_t num_radial_sections = 128;
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
         const std::size_t num_polar_sections = 1;
         const std::size_t num_azimuthal_sections = 1;
         const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
         const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
                                            num_azimuthal_sections, sphere_center);
-        const double t_begin = 0.0;
-        const double t_end = sphere_max_radius * 3;
-        const BoundVec3 ray_origin(-421.875, -562.5, -(sphere_max_radius + 1.0));
-        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
+        const FreeVec3 ray_direction(0.0, 0.0, -1.0);
         const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
         const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
-        // TODO: Fix expected values.
-        std::vector<int> expected_radial_voxels(119 * 2 - 1);
-        std::iota(expected_radial_voxels.begin(), expected_radial_voxels.begin() + 119, 1);
-        std::iota(expected_radial_voxels.rbegin(), expected_radial_voxels.rbegin() + 119 - 1, 1);
-
-        std::vector<int> expected_theta_voxels(119 * 2 - 1);
-        std::vector<int> expected_phi_voxels(119 * 2 - 1);
-        std::fill(expected_theta_voxels.begin(), expected_theta_voxels.end(), 1); // { 1, 1, ..., 1, 1 }
-        std::fill(expected_phi_voxels.begin(), expected_phi_voxels.end(), 1);     // { 1, 1, ..., 1, 1 }
-
+        const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 2, 1};
+        const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0, 0};
+        const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 


### PR DESCRIPTION
Updated the sectored sphere implementation so that the minimum boundaries are part of the grid. Now, the deltas are determined by (max_bound_X - min_bound_X) / num_X_sections

Fixes the tangential hit bug. 
- Before:
```
const bool is_tangential_hit =  isEqual(intersection_times[0], intersection_times[1])
```
- After:
```
const bool is_tangential_hit = intersection_times[0] > t && isEqual(intersection_times[0], intersection_times[1])
```