### PR TITLE
Optimize & simplify radialHit(), add test for radial voxel 0 and sphere not at origin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## About
 [![spherical-volume-rendering](https://circleci.com/gh/spherical-volume-rendering/svr-algorithm.svg?style=shield)](https://app.circleci.com/pipelines/github/spherical-volume-rendering/svr-algorithm)
+[![codecov](https://codecov.io/gh/cgyurgyik/algorithm-team-collaboration/branch/master/graph/badge.svg)](https://codecov.io/gh/cgyurgyik/algorithm-team-collaboration)
 
 This project extends the [yt](https://yt-project.org/) open-source data analysis and visualization package, providing an enhanced, integrated user interface for data exploration and enabling the visualization of physical data that comes from non-cartesian grids. Currently, yt implements a fast voxel traversal over a cartesian coordinate grid. The objective is to develop a fast voxel traversal over a spherical coordinate grid, based on ideas from Amanatides and Woo’s seminal paper on fast voxel traversal for ray tracing.
 

--- a/cpp/benchmarks/benchmark_SVR.cpp
+++ b/cpp/benchmarks/benchmark_SVR.cpp
@@ -29,7 +29,7 @@ namespace {
     // Since the maximum sphere radius is 10e4, this ensures all rays will intersect.
     void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10e3;
+        const double sphere_max_radius = 10e2;
         const std::size_t num_radial_sections = Y;
         const std::size_t num_polar_sections = Y;
         const std::size_t num_azimuthal_sections = Y;
@@ -40,6 +40,7 @@ namespace {
         const double t_begin = 0.0;
         const double t_end = sphere_max_radius * 3;
 
+        const FreeVec3  ray_direction(0.0, 0.0, 1.0);
         double ray_origin_x = -1000.0;
         double ray_origin_y = -1000.0;
         const double ray_origin_z = -(sphere_max_radius + 1.0);
@@ -48,19 +49,21 @@ namespace {
         for (std::size_t i = 0; i < X; ++i) {
             for (std::size_t j = 0; j < X; ++j) {
                 const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-                const FreeVec3  ray_direction(0.0, 0.0, 1.0);
                 const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
                 #if DEBUG
-                const std::size_t last = actual_voxels.size() == 0 ? 0 : actual_voxels.size() - 1;
-                if (actual_voxels[0].radial != 1 || actual_voxels[last].radial != 1 || actual_voxels.size() < 2) {
-                    printf("\nDid not complete entire traversal.");
-                    const auto first_voxel = actual_voxels[0];
-                    const auto last_voxel = actual_voxels[last];
-                    printf("\nRay origin: {%f, %f, %f}", ray_origin_x, ray_origin_y, ray_origin_z);
-                    printf("\nEntrance Voxel: {%d, %d, %d} ... Exit Voxel: {%d, %d, %d}",
-                           first_voxel.radial, first_voxel.polar, first_voxel.azimuthal,
-                           last_voxel.radial, last_voxel.polar, last_voxel.azimuthal);
-                    for (const auto v : actual_voxels) printf("{%d, %d, %d} , ", v.radial, v.polar, v.azimuthal);
+                if (actual_voxels.size() == 0 ) { printf("\n No intersection at all."); }
+                else {
+                    const std::size_t last = actual_voxels.size() - 1;
+                    if (actual_voxels[0].radial != 1 || actual_voxels[last].radial != 1 || actual_voxels.size() < 2) {
+                        printf("\nDid not complete entire traversal.");
+                        const auto first_voxel = actual_voxels[0];
+                        const auto last_voxel = actual_voxels[last];
+                        printf("\nRay origin: {%f, %f, %f}", ray_origin_x, ray_origin_y, ray_origin_z);
+                        printf("\nEntrance Voxel: {%d, %d, %d} ... Exit Voxel: {%d, %d, %d}",
+                               first_voxel.radial, first_voxel.polar, first_voxel.azimuthal,
+                               last_voxel.radial, last_voxel.polar, last_voxel.azimuthal);
+                        for (const auto v : actual_voxels) printf("{%d, %d, %d} , ", v.radial, v.polar, v.azimuthal);
+                    }
                 }
                 # endif
                 ray_origin_y = (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;

--- a/cpp/benchmarks/benchmark_SVR.cpp
+++ b/cpp/benchmarks/benchmark_SVR.cpp
@@ -29,7 +29,7 @@ namespace {
     // Since the maximum sphere radius is 10e4, this ensures all rays will intersect.
     void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10e2;
+        const double sphere_max_radius = 10e4;
         const std::size_t num_radial_sections = Y;
         const std::size_t num_polar_sections = Y;
         const std::size_t num_azimuthal_sections = Y;

--- a/cpp/benchmarks/benchmark_SVR.cpp
+++ b/cpp/benchmarks/benchmark_SVR.cpp
@@ -18,18 +18,18 @@
 
 namespace {
 
-    // Sends X^2 rays through a Y^3 voxel sphere with maximum radius 10e6.
+    // Sends X^2 rays through a Y^3 voxel sphere with maximum radius 10e4.
     // The set up is the following:
     // This traversal is orthographic in nature, and all rays will intersect the sphere.
-    // In the X plane: Ray origin moves incrementally from [-10,000.0, 10,000.0].
-    // In the Y plane: Ray origin moves incrementally from [-10,000.0, 10,000.0].
-    // In the Z plane: Ray origin begins at -(10e6 + 1.0). It does not move in the Z plane.
+    // In the X plane: Ray origin moves incrementally from [-1,000.0, 1,000.0].
+    // In the Y plane: Ray origin moves incrementally from [-1,000.0, 1,000.0].
+    // In the Z plane: Ray origin begins at -(10e4 + 1.0). It does not move in the Z plane.
     // From this, one can infer that the ray moves incrementally in the XY plane from
-    // (-10,000.0, -10,000.0) -> (10,000.0, 10,000.0) while remaining outside the sphere in the Z plane.
-    // Since the maximum sphere radius is 10e6, this ensures all rays will intersect.
+    // (-1,000.0, -1,000.0) -> (1,000.0, 1,000.0) while remaining outside the sphere in the Z plane.
+    // Since the maximum sphere radius is 10e4, this ensures all rays will intersect.
     void inline orthographicTraverseXSquaredRaysinYCubedVoxels(const std::size_t X, const std::size_t Y) noexcept {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10e6;
+        const double sphere_max_radius = 10e3;
         const std::size_t num_radial_sections = Y;
         const std::size_t num_polar_sections = Y;
         const std::size_t num_azimuthal_sections = Y;
@@ -40,29 +40,30 @@ namespace {
         const double t_begin = 0.0;
         const double t_end = sphere_max_radius * 3;
 
-        double ray_origin_x = -10000.0;
-        double ray_origin_y = -10000.0;
+        double ray_origin_x = -1000.0;
+        double ray_origin_y = -1000.0;
         const double ray_origin_z = -(sphere_max_radius + 1.0);
 
-        const double ray_origin_plane_movement = 20000.0 / X;
+        const double ray_origin_plane_movement = 2000.0 / X;
         for (std::size_t i = 0; i < X; ++i) {
             for (std::size_t j = 0; j < X; ++j) {
                 const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
                 const FreeVec3  ray_direction(0.0, 0.0, 1.0);
                 const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
                 #if DEBUG
-                const std::size_t last = actual_voxels.size() - 1;
-                if (actual_voxels[0].radial_voxel != 1 || actual_voxels[last].radial_voxel != 1) {
+                const std::size_t last = actual_voxels.size() == 0 ? 0 : actual_voxels.size() - 1;
+                if (actual_voxels[0].radial != 1 || actual_voxels[last].radial != 1 || actual_voxels.size() < 2) {
                     printf("\nDid not complete entire traversal.");
                     const auto first_voxel = actual_voxels[0];
                     const auto last_voxel = actual_voxels[last];
                     printf("\nRay origin: {%f, %f, %f}", ray_origin_x, ray_origin_y, ray_origin_z);
                     printf("\nEntrance Voxel: {%d, %d, %d} ... Exit Voxel: {%d, %d, %d}",
-                           first_voxel.radial_voxel, first_voxel.polar_voxel, first_voxel.azimuthal_voxel,
-                           last_voxel.radial_voxel, last_voxel.polar_voxel, last_voxel.azimuthal_voxel);
+                           first_voxel.radial, first_voxel.polar, first_voxel.azimuthal,
+                           last_voxel.radial, last_voxel.polar, last_voxel.azimuthal);
+                    for (const auto v : actual_voxels) printf("{%d, %d, %d} , ", v.radial, v.polar, v.azimuthal);
                 }
                 # endif
-                ray_origin_y = (j == X - 1) ? -10000.0 : ray_origin_y + ray_origin_plane_movement;
+                ray_origin_y = (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
             }
             ray_origin_x += ray_origin_plane_movement;
         }

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -60,6 +60,26 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_sphere_center_not_at_origin(self):
+        ray_origin = np.array([-11.0, -11.0, -11.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([2.0, 2.0, 2.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,4,3,2,1]
+        expected_theta_voxels = [2,2,2,2,0,0,0,0]
+        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
     def test_ray_begins_within_sphere(self):
         ray_origin = np.array([-3.0, 4.0, 5.0])
         ray_direction = np.array([1.0, -1.0, -1.0])
@@ -647,6 +667,24 @@ class TestWalkSphericalVolume(unittest.TestCase):
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
                                                   sphere_center, t_begin, t_end)
         assert voxels.size == 0
+
+    def test_avoid_ray_stepping_to_radial_voxel_zero(self):
+        ray_origin = np.array([-984.375, 250.0, -10001.0])
+        ray_direction = np.array([0.0, 0.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10e3
+        num_radial_sections = 128
+        num_polar_sections = 128
+        num_azimuthal_sections = 128
+        t_begin = 0.0
+        t_end = 35.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        last_idx = voxels.size - 1
+        assert(voxels[last_idx].radial != 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -677,14 +677,14 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 128
         num_azimuthal_sections = 128
         t_begin = 0.0
-        t_end = 35.0
+        t_end = sphere_max_radius * 3
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
                                                   sphere_center, t_begin, t_end)
-        last_idx = voxels.size - 1
-        assert(voxels[last_idx].radial != 0)
+        last_radial_voxel = voxels[voxels[0].size - 1][0]
+        assert(last_radial_voxel != 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -160,6 +160,26 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [1,1,1,0,0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_ray_begins_and_ends_within_sphere_not_centered_at_origin(self):
+        ray_origin = np.array([-1.0, 7.0, 7.0])
+        ray_direction = np.array([1.0, -1.0, -1.0])
+        sphere_center = np.array([2.0, 3.0, 2.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 5.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [2,3,4,4,4]
+        expected_theta_voxels = [1,1,1,0,3]
+        expected_phi_voxels = [1,1,1,0,0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
     def test_ray_slight_offset_in_XY_plane(self):
         ray_origin = np.array([-13.0, -13.0, -13.0])
         ray_direction = np.array([1.0, 1.5, 1.0])

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -281,14 +281,14 @@ namespace svr {
                              grid.pMaxPolar(current_polar_voxel).P2, 0.0);
         const FreeVec3 p_two(grid.pMaxPolar(current_polar_voxel + 1).P1,
                              grid.pMaxPolar(current_polar_voxel + 1).P2, 0.0);
-        const BoundVec3 u_min(grid.centerToPolarBound(current_polar_voxel));
-        const BoundVec3 u_max(grid.centerToPolarBound(current_polar_voxel + 1));
+        const BoundVec3 *u_min = &grid.centerToPolarBound(current_polar_voxel);
+        const BoundVec3 *u_max = &grid.centerToPolarBound(current_polar_voxel + 1);
         const FreeVec3 w_min = p_one - FreeVec3(ray_segment.P1());
         const FreeVec3 w_max = p_two - FreeVec3(ray_segment.P1());
-        const double perp_uv_min = u_min.x() * ray_segment.vector().y() - u_min.y() * ray_segment.vector().x();
-        const double perp_uv_max = u_max.x() * ray_segment.vector().y() - u_max.y() * ray_segment.vector().x();
-        const double perp_uw_min = u_min.x() * w_min.y() - u_min.y() * w_min.x();
-        const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
+        const double perp_uv_min = u_min->x() * ray_segment.vector().y() - u_min->y() * ray_segment.vector().x();
+        const double perp_uv_max = u_max->x() * ray_segment.vector().y() - u_max->y() * ray_segment.vector().x();
+        const double perp_uw_min = u_min->x() * w_min.y() - u_min->y() * w_min.x();
+        const double perp_uw_max = u_max->x() * w_max.y() - u_max->y() * w_max.x();
         const double perp_vw_min = ray_segment.vector().x() * w_min.y() - ray_segment.vector().y() * w_min.x();
         const double perp_vw_max = ray_segment.vector().x() * w_max.y() - ray_segment.vector().y() * w_max.x();
         return angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -6,9 +6,6 @@
 #include <limits>
 
 namespace svr {
-    // Represents an invalid time. At no point should the time be a negative number.
-    constexpr double INVALID_TIME = -1.0;
-
     // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
     enum VoxelIntersectionType {
         None = 0,
@@ -33,13 +30,14 @@ namespace svr {
         bool within_bounds;
     };
 
-    // Metadata for the radial hit parameters.
+    // Metadata for the radial hit parameters. There are two main components of the metadata: the transition flag and
+    // the previous radial voxel. The transition flag is necessary to determine when tStepR's sign changes, and
+    // the previous radial voxel ensures we do not hit the same voxel twice in the case of a tangential hit.
     struct RadialHitMetadata {
     public:
-        inline bool radialTransitionOccurred() const noexcept { return transition_flag_; }
+        inline bool radialTransitionHasOccurred() const noexcept { return transition_flag_; }
 
-        // Once a radial transition has occurred, it follows that all radial intersections will have the same flag.
-        inline void isRadialTransition(bool b) noexcept { transition_flag_ |= b; }
+        inline void isRadialTransition(bool b) noexcept { transition_flag_ = b; }
 
         inline int previousRadialVoxel() const noexcept { return previous_radial_voxel_; }
 
@@ -76,7 +74,7 @@ namespace svr {
         }
 
         // Calculates the updated ray segment intersection point given an intersect parameter.
-        // More information on this use case can be found at:
+        // More information on the use case can be found at:
         // http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
         inline double intersectionTimeAt(double intersect_parameter, const Ray &ray) const noexcept {
             return (P1_[NZDI_] + ray_segment_[NZDI_] * intersect_parameter - ray.origin()[NZDI_])
@@ -87,7 +85,7 @@ namespace svr {
 
         inline const BoundVec3 &P2() const noexcept { return P2_; }
 
-        inline const FreeVec3 &raySegment() const noexcept { return ray_segment_; }
+        inline const FreeVec3 &vector() const noexcept { return ray_segment_; }
 
     private:
         // The end point of the ray segment.
@@ -99,7 +97,7 @@ namespace svr {
         // The begin point of the ray segment.
         BoundVec3 P1_;
 
-        // P2 - P1.
+        // The free vector represented by P2 - P1.
         FreeVec3 ray_segment_;
     };
 
@@ -162,53 +160,55 @@ namespace svr {
     inline HitParameters radialHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
                                    RadialHitMetadata &rh_metadata, int current_radial_voxel,
                                    double v, double rsvd_minus_v_squared, double t, double t_end) noexcept {
-        rh_metadata.updatePreviousRadialVoxel(current_radial_voxel);
-        const std::size_t voxel_idx = current_radial_voxel - 1;
-        const double current_radius = grid.deltaRadii(voxel_idx);
+        const std::size_t previous_idx = std::min(static_cast<std::size_t>(current_radial_voxel),
+                                                  grid.numRadialSections() - 1);
+        if (!rh_metadata.radialTransitionHasOccurred()) {
+            rh_metadata.updatePreviousRadialVoxel(current_radial_voxel);
+            const double r_a = grid.deltaRadiiSquared(previous_idx -
+                                                      (grid.deltaRadiiSquared(previous_idx) < rsvd_minus_v_squared));
+            const double d_a = std::sqrt(r_a - rsvd_minus_v_squared);
+            const double intersection_t1 = ray.timeOfIntersectionAt(v - d_a);
+            const double intersection_t2 = ray.timeOfIntersectionAt(v + d_a);
 
-        // Find the intersection times for the ray and the previous radial disc.
-        const std::size_t previous_idx = std::min(voxel_idx + 1, grid.numRadialSections() - 1);
-        const double r_a = grid.deltaRadiiSquared(previous_idx -
-                                                  (grid.deltaRadiiSquared(previous_idx) < rsvd_minus_v_squared));
-        const double d_a = std::sqrt(r_a - rsvd_minus_v_squared);
+            const double t1_gt_t = intersection_t1 > t;
+            if (t1_gt_t && intersection_t1 == intersection_t2) {
+                // Tangential hit. Every tangential hit leads to a radial transition.
+                rh_metadata.isRadialTransition(true);
+                return {.tMax=intersection_t1, .tStep=0, .within_bounds=true };
+            }
+            if (t1_gt_t && intersection_t1 < t_end) {
+                return {.tMax=intersection_t1, .tStep=1, .within_bounds=true };
+            }
 
-        std::array<double, 4> intersection_times;
-        intersection_times[0] = ray.timeOfIntersectionAt(v - d_a);
-        intersection_times[1] = ray.timeOfIntersectionAt(v + d_a);
+            if (t < intersection_t2 && intersection_t2 < t_end) {
+                // The time represented is with the further point of intersection of the current sphere.
+                // Since t1 is not within our time bounds, it must be true that this is a radial transition.
+                rh_metadata.isRadialTransition(true);
+                return {.tMax=intersection_t2, .tStep=-1, .within_bounds=true };
+            }
 
-        // To find the next radius, we need to check the previous_transition_flag:
-        // In the case that the ray has sequential hits with equal radii, e.g.
-        // the innermost radial disc, this ensures that the proper radii are being checked.
-        const double transition_radii[] = {grid.deltaRadiiSquared(std::min(voxel_idx - 1, std::size_t{0})),
-                                           grid.deltaRadiiSquared(voxel_idx)};
-        const double r_b = transition_radii[rh_metadata.radialTransitionOccurred()];
-        if (r_b >= rsvd_minus_v_squared) {
-            const double d_b = std::sqrt(r_b - rsvd_minus_v_squared);
-            intersection_times[2] = ray.timeOfIntersectionAt(v - d_b);
-            intersection_times[3] = ray.timeOfIntersectionAt(v + d_b);
-        }
-        const auto intersection_time_it = std::find_if(intersection_times.cbegin(), intersection_times.cend(),
-                                                       [t, t_end](double intersection_time) -> double {
-                                                           return intersection_time > t && intersection_time < t_end;
-                                                       });
-        if (intersection_time_it == intersection_times.cend()) {
+            // There does not exist an intersection time X such that t < X < t_end.
             return {.tMax=std::numeric_limits<double>::max(), .tStep=0, .within_bounds=false};
         }
-        if (intersection_times[0] > t && svr::isEqual(intersection_times[0], intersection_times[1])) {
-            rh_metadata.isRadialTransition(true);
-            return {.tMax=intersection_times[0],
-                    .tStep=0,
+
+        const double d_a = std::sqrt(grid.deltaRadiiSquared(previous_idx) - rsvd_minus_v_squared);
+        const double intersection_t1 = ray.timeOfIntersectionAt(v + d_a);
+        if (t < intersection_t1 && intersection_t1 < t_end) {
+            return {.tMax=intersection_t1,
+                    .tStep=-1,
                     .within_bounds=true
             };
         }
-        const double intersection_time = *intersection_time_it;
-        const double r_new = (ray.pointAtParameter(intersection_time) - grid.sphereCenter()).length();
-        rh_metadata.isRadialTransition(svr::isEqual(r_new, current_radius));
-        const int step[] = {-1, 1};
-        return {.tMax=intersection_time,
-                .tStep=step[(!rh_metadata.radialTransitionOccurred() && r_new < current_radius)],
-                .within_bounds=true
-        };
+        const double d_b = std::sqrt(grid.deltaRadiiSquared(current_radial_voxel - 1) - rsvd_minus_v_squared);
+        const double intersection_t2 = ray.timeOfIntersectionAt(v + d_b);
+        if (t < intersection_t2 && intersection_t2 < t_end) {
+            return {.tMax=intersection_t2,
+                    .tStep=-1,
+                    .within_bounds=true
+            };
+        }
+        // There does not exist an intersection time X such that t < X < t_end.
+        return {.tMax=std::numeric_limits<double>::max(), .tStep=0, .within_bounds=false};
     }
 
     // A generalized version of the latter half of the polar and azimuthal hit parameters. Since the only difference
@@ -217,7 +217,7 @@ namespace svr {
     // Reference: http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
     HitParameters angularHit(const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min,
                              double perp_uv_max, double perp_uw_min, double perp_uw_max, double perp_vw_min,
-                             double perp_vw_max, const RaySegment &RS,
+                             double perp_vw_max, const RaySegment &ray_segment,
                              const std::array<double, 2> &collinear_times, double t, double t_end,
                              double ray_direction_2, double sphere_center_2,
                              const std::vector<svr::LineSegment> &P_max, int current_voxel) noexcept {
@@ -236,7 +236,7 @@ namespace svr {
             b = perp_uw_min * inv_perp_uv_min;
             if (!((svr::lessThan(a, 0.0) || svr::lessThan(1.0, a)) || svr::lessThan(b, 0.0) || svr::lessThan(1.0, b))) {
                 is_intersect_min = true;
-                t_min = RS.intersectionTimeAt(b, ray);
+                t_min = ray_segment.intersectionTimeAt(b, ray);
             }
         }
         double t_max = collinear_times[is_collinear_max];
@@ -247,7 +247,7 @@ namespace svr {
             b = perp_uw_max * inv_perp_uv_max;
             if (!((svr::lessThan(a, 0.0) || svr::lessThan(1.0, a)) || svr::lessThan(b, 0.0) || svr::lessThan(1.0, b))) {
                 is_intersect_max = true;
-                t_max = RS.intersectionTimeAt(b, ray);
+                t_max = ray_segment.intersectionTimeAt(b, ray);
             }
         }
 
@@ -293,7 +293,7 @@ namespace svr {
     // Determines whether a polar hit occurs for the given ray. A polar hit is considered an intersection with
     // the ray and a polar section. The polar sections live in the XY plane.
     inline HitParameters polarHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                  const RaySegment &RS, const std::array<double, 2> &collinear_times,
+                                  const RaySegment &ray_segment, const std::array<double, 2> &collinear_times,
                                   int current_polar_voxel, double t, double t_end) noexcept {
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxPolar(current_polar_voxel).P1,
@@ -302,16 +302,16 @@ namespace svr {
                              grid.pMaxPolar(current_polar_voxel + 1).P2, 0.0);
         const BoundVec3 u_min(grid.centerToPolarBound(current_polar_voxel));
         const BoundVec3 u_max(grid.centerToPolarBound(current_polar_voxel + 1));
-        const FreeVec3 w_min = p_one - FreeVec3(RS.P1());
-        const FreeVec3 w_max = p_two - FreeVec3(RS.P1());
-        const double perp_uv_min = u_min.x() * RS.raySegment().y() - u_min.y() * RS.raySegment().x();
-        const double perp_uv_max = u_max.x() * RS.raySegment().y() - u_max.y() * RS.raySegment().x();
+        const FreeVec3 w_min = p_one - FreeVec3(ray_segment.P1());
+        const FreeVec3 w_max = p_two - FreeVec3(ray_segment.P1());
+        const double perp_uv_min = u_min.x() * ray_segment.vector().y() - u_min.y() * ray_segment.vector().x();
+        const double perp_uv_max = u_max.x() * ray_segment.vector().y() - u_max.y() * ray_segment.vector().x();
         const double perp_uw_min = u_min.x() * w_min.y() - u_min.y() * w_min.x();
         const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
-        const double perp_vw_min = RS.raySegment().x() * w_min.y() - RS.raySegment().y() * w_min.x();
-        const double perp_vw_max = RS.raySegment().x() * w_max.y() - RS.raySegment().y() * w_max.x();
+        const double perp_vw_min = ray_segment.vector().x() * w_min.y() - ray_segment.vector().y() * w_min.x();
+        const double perp_vw_max = ray_segment.vector().x() * w_max.y() - ray_segment.vector().y() * w_max.x();
         return angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
-                          perp_uw_max, perp_vw_min, perp_vw_max, RS,
+                          perp_uw_max, perp_vw_min, perp_vw_max, ray_segment,
                           collinear_times, t, t_end, ray.direction().y(),
                           grid.sphereCenter().y(), grid.pMaxPolar(),
                           current_polar_voxel);
@@ -321,7 +321,7 @@ namespace svr {
     // considered an intersection with the ray and an azimuthal section.
     // The azimuthal sections live in the XZ plane.
     inline HitParameters azimuthalHit(const Ray &ray, const svr::SphericalVoxelGrid &grid,
-                                      const RaySegment &RS, const std::array<double, 2> &collinear_times,
+                                      const RaySegment &ray_segment, const std::array<double, 2> &collinear_times,
                                       int current_azimuthal_voxel, double t, double t_end) noexcept {
         // Calculate the voxel boundary vectors.
         const FreeVec3 p_one(grid.pMaxAzimuthal(current_azimuthal_voxel).P1, 0.0,
@@ -330,16 +330,16 @@ namespace svr {
                              grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P2);
         const BoundVec3 *u_min = &grid.centerToAzimuthalBound(current_azimuthal_voxel);
         const BoundVec3 *u_max = &grid.centerToAzimuthalBound(current_azimuthal_voxel + 1);
-        const FreeVec3 w_min = p_one - FreeVec3(RS.P1());
-        const FreeVec3 w_max = p_two - FreeVec3(RS.P1());
-        const double perp_uv_min = u_min->x() * RS.raySegment().z() - u_min->z() * RS.raySegment().x();
-        const double perp_uv_max = u_max->x() * RS.raySegment().z() - u_max->z() * RS.raySegment().x();
+        const FreeVec3 w_min = p_one - FreeVec3(ray_segment.P1());
+        const FreeVec3 w_max = p_two - FreeVec3(ray_segment.P1());
+        const double perp_uv_min = u_min->x() * ray_segment.vector().z() - u_min->z() * ray_segment.vector().x();
+        const double perp_uv_max = u_max->x() * ray_segment.vector().z() - u_max->z() * ray_segment.vector().x();
         const double perp_uw_min = u_min->x() * w_min.z() - u_min->z() * w_min.x();
         const double perp_uw_max = u_max->x() * w_max.z() - u_max->z() * w_max.x();
-        const double perp_vw_min = RS.raySegment().x() * w_min.z() - RS.raySegment().z() * w_min.x();
-        const double perp_vw_max = RS.raySegment().x() * w_max.z() - RS.raySegment().z() * w_max.x();
+        const double perp_vw_min = ray_segment.vector().x() * w_min.z() - ray_segment.vector().z() * w_min.x();
+        const double perp_vw_max = ray_segment.vector().x() * w_max.z() - ray_segment.vector().z() * w_max.x();
         return angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
-                          perp_uw_max, perp_vw_min, perp_vw_max, RS,
+                          perp_uw_max, perp_vw_min, perp_vw_max, ray_segment,
                           collinear_times, t, t_end, ray.direction().z(),
                           grid.sphereCenter().z(), grid.pMaxAzimuthal(),
                           current_azimuthal_voxel);
@@ -492,7 +492,8 @@ namespace svr {
         }
 
         // Initialize the time in case of collinear min or collinear max for angular plane hits.
-        const std::array<double, 2> collinear_times = {INVALID_TIME, ray.timeOfIntersectionAt(grid.sphereCenter())};
+        // In the case where the hit is not collinear, a time of 0.0 is inputted.
+        const std::array<double, 2> collinear_times = {0.0, ray.timeOfIntersectionAt(grid.sphereCenter())};
 
         RadialHitMetadata rh_metadata;
         rh_metadata.updatePreviousRadialVoxel(current_radial_voxel);
@@ -501,6 +502,7 @@ namespace svr {
         while (true) {
             const auto radial = radialHit(ray, grid, rh_metadata, current_radial_voxel,
                                           v, rsvd_minus_v_squared, t, t_end);
+            if (current_radial_voxel + radial.tStep == 0) { return voxels; }
             ray_segment.updateAtTime(t, ray);
             const auto polar = polarHit(ray, grid, ray_segment, collinear_times,
                                         current_polar_voxel, t, t_end);
@@ -549,9 +551,7 @@ namespace svr {
                     current_azimuthal_voxel = (current_azimuthal_voxel + azimuthal.tStep) % grid.numAzimuthalSections();
                     break;
                 }
-                case None: {
-                    return voxels;
-                }
+                case None: { return voxels; }
             }
             voxels.push_back({.radial=current_radial_voxel,
                               .polar=current_polar_voxel,

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -160,16 +160,11 @@ namespace svr {
         if (rh_metadata.radialStepTransitionHasOccurred()) {
             const double d_b = std::sqrt(grid.deltaRadiiSquared(current_radial_voxel - 1) - rsvd_minus_v_squared);
             const double intersection_t = ray.timeOfIntersectionAt(v + d_b);
-            if (intersection_t < t_end) {
-                return {.tMax=intersection_t,
-                        .tStep=-1,
-                        .within_bounds=true
-                };
-            }
+            if (intersection_t < t_end) { return {.tMax=intersection_t, .tStep=-1, .within_bounds=true }; }
+
             // There does not exist an intersection time X such that t < X < t_end.
             return {.tMax=std::numeric_limits<double>::max(), .tStep=0, .within_bounds=false};
         }
-
         const std::size_t previous_idx = std::min(static_cast<std::size_t>(current_radial_voxel),
                                                   grid.numRadialSections() - 1);
         rh_metadata.updatePreviousRadialVoxel(current_radial_voxel);
@@ -189,7 +184,7 @@ namespace svr {
             return {.tMax=intersection_t1, .tStep=1, .within_bounds=true };
         }
 
-        if (t < intersection_t2 && intersection_t2 < t_end) {
+        if (intersection_t2 < t_end) {
             // t2 is the "further" point of intersection of the current sphere.
             // Since t1 is not within our time bounds, it must be true that this is a radial transition.
             rh_metadata.isRadialStepTransition(true);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -413,12 +413,13 @@ namespace svr {
 
         const double rsvd_begin = rsv_begin.dot(rsv_begin);
         std::size_t idx = grid.numRadialSections();
-        const auto it = std::find_if(grid.deltaRadiiSquared().crbegin() + 1, grid.deltaRadiiSquared().crend(),
+        const auto outermost_radius_it = grid.deltaRadiiSquared().crend();
+        const auto it = std::find_if(grid.deltaRadiiSquared().crbegin() + 1, outermost_radius_it,
                                      [rsvd_begin, &idx](double dR_squared) -> bool {
                                          --idx;
                                          return rsvd_begin <= dR_squared;
                                      });
-        const bool ray_origin_is_outside_grid = (it == grid.deltaRadiiSquared().crend());
+        const bool ray_origin_is_outside_grid = (it == outermost_radius_it);
         const double max_radius_squared = grid.deltaRadiiSquared()[0];
         const double entry_radius_squared = ray_origin_is_outside_grid ? max_radius_squared : *it;
         const double entry_radius = grid.deltaRadii()[idx];

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -160,13 +160,13 @@ namespace svr {
         if (rh_metadata.radialStepTransitionHasOccurred()) {
             const double d_b = std::sqrt(grid.deltaRadiiSquared(current_radial_voxel - 1) - rsvd_minus_v_squared);
             const double intersection_t = ray.timeOfIntersectionAt(v + d_b);
-            if (intersection_t < t_end && current_radial_voxel != 1) {
+            if (intersection_t < t_end) {
                 return {.tMax=intersection_t,
                         .tStep=-1,
                         .within_bounds=true
                 };
             }
-            // There does not exist an intersection time X such that t < X < t_end or the next radial voxel is 0.
+            // There does not exist an intersection time X such that t < X < t_end.
             return {.tMax=std::numeric_limits<double>::max(), .tStep=0, .within_bounds=false};
         }
 
@@ -491,6 +491,7 @@ namespace svr {
         while (true) {
             const auto radial = radialHit(ray, grid, rh_metadata, current_radial_voxel,
                                           v, rsvd_minus_v_squared, t, t_end);
+            if (current_radial_voxel == 0) { return voxels; }
             ray_segment.updateAtTime(t, ray);
             const auto polar = polarHit(ray, grid, ray_segment, collinear_times,
                                         current_polar_voxel, t, t_end);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -444,7 +444,7 @@ namespace svr {
 
         const FreeVec3 ray_sphere = ray_origin_is_outside_grid ?
                                     grid.sphereCenter() - ray.pointAtParameter(t_sphere_entrance) :
-                                    svr::isEqual(rsv_begin, Vec3(0.0, 0.0, 0.0)) ?
+                                    rsv_begin == FreeVec3(0.0, 0.0, 0.0) ?
                                     grid.sphereCenter() - ray.pointAtParameter(t_begin + 0.1) : rsv_begin;
 
         int current_polar_voxel = initializeAngularVoxelID(grid, grid.numPolarSections(), ray_sphere, P_polar,

--- a/cpp/tests/.travis.yml
+++ b/cpp/tests/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+os: linux
+compiler: gcc
+
+cache: # see https://docs.travis-ci.com/user/caching/
+  - directories:
+      - $HOME/.cache
+
+addons:
+  apt:
+    packages: lcov
+
+install:
+  # (fake) install dependencies (usually involves wget, configure, make, ...)
+  # install into cache folder (build binaries+headers only, no sources and do NOT build there)
+  - mkdir -p $HOME/.cache
+
+script: ./build.sh
+
+after_success:
+  # Create lcov report
+  # capture coverage info
+  - lcov --directory . --capture --output-file coverage.info
+  # filter out system and extra files.
+  # To also not include test code in coverage add them with full path to the patterns: '*/tests/*'
+  - lcov --remove coverage.info '/usr/*' "${HOME}"'/.cache/*' --output-file coverage.info
+  # output coverage data for debugging (optional)
+  - lcov --list coverage.info
+  # Uploading to CodeCov
+  # '-f' specifies file(s) to use and disables manual coverage gathering and file search which has already been done above
+  - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+
+notifications:
+  email:
+    - cpg49@cornell.edu

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -26,21 +26,25 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
 
-#if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-#    add_link_options(-Wall -fprofile-arcs -ftest-coverage -fprofile-instr-generate)
-#    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-#elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-#    add_compile_options(--coverage)
-#elseif ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GCC")
-#    add_compile_options(-fprofile-arcs -ftest-coverage)
-#endif ()
+
+# Don't use e.g. GNU extension (like -std=gnu++11) for portability
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Code Coverage Configuration
+add_library(coverage_config INTERFACE)
+
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+    add_link_options(-fprofile-instr-generate)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(--coverage)
+endif ()
 
 set(TESTING_BINARY test_${CMAKE_PROJECT_NAME})
 set(TESTING_SOURCE_FILES ../spherical_volume_rendering_util.cpp test_SVR.cpp ../floating_point_comparison_util.h)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 add_executable(${TESTING_BINARY} ${TESTING_SOURCE_FILES})
 target_link_libraries(${TESTING_BINARY} gtest_main gmock_main)
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -Wextra")
 
 enable_testing()
 

--- a/cpp/tests/build.sh
+++ b/cpp/tests/build.sh
@@ -1,0 +1,1 @@
+ cd cpp/tests && mkdir build && cd build && cmake .. && make && cd .. && ./bin/test_SVR

--- a/cpp/tests/test_SVR.cpp
+++ b/cpp/tests/test_SVR.cpp
@@ -766,6 +766,40 @@ namespace {
         EXPECT_NE(actual_voxels[last_idx].radial, 0);
     }
 
+    TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
+        // Given an orthographic ray projection with sufficient time, all rays should enter and exit the sphere.
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10e4;
+        const std::size_t num_radial_sections = 64;
+        const std::size_t num_polar_sections = 64;
+        const std::size_t num_azimuthal_sections = 64;
+        const svr::SphereBound min_bound = {.radial=0.0, .polar=0.0, .azimuthal=0.0};
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=2 * M_PI, .azimuthal=2 * M_PI};
+        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
+        const double t_begin = 0.0;
+        const double t_end = sphere_max_radius * 3;
+
+        const FreeVec3  ray_direction(0.0, 0.0, 1.0);
+        double ray_origin_x = -1000.0;
+        double ray_origin_y = -1000.0;
+        const double ray_origin_z = -(sphere_max_radius + 1.0);
+
+        const double ray_origin_plane_movement = 2000.0 / 30;
+        for (std::size_t i = 0; i < 30; ++i) {
+            for (std::size_t j = 0; j < 30; ++j) {
+                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
+                const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+                EXPECT_NE(actual_voxels.size(), 0);
+                EXPECT_EQ(actual_voxels[0].radial, 1);
+                const std::size_t last = actual_voxels.size() - 1;
+                EXPECT_EQ(actual_voxels[last].radial, 1);
+                ray_origin_y = (j == 30 - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
+            }
+            ray_origin_x += ray_origin_plane_movement;
+        }
+    }
+
     TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -44,6 +44,10 @@ public:
         return e_[0] * e_[0] + e_[1] * e_[1] + e_[2] * e_[2];
     }
 
+    inline bool operator==(const Vec3 &other) const noexcept {
+        return this->x() == other.x() && this->y() == other.y() && this->z() == other.z();
+    }
+
     inline double operator[](const std::size_t index) const noexcept {
         return e_[index];
   }
@@ -96,6 +100,10 @@ struct FreeVec3 : Vec3 {
         this->z() /= scalar;
         return *this;
     }
+
+    inline bool operator==(const FreeVec3 &other) const noexcept {
+        return this->x() == other.x() && this->y() == other.y() && this->z() == other.z();
+    }
 };
 
 inline FreeVec3 operator+(const FreeVec3 &v) noexcept { return v; }
@@ -142,6 +150,10 @@ struct BoundVec3 : Vec3 {
 
     inline BoundVec3 &operator-=(const FreeVec3 &other) noexcept {
         return *this += (-other);
+    }
+
+    inline bool operator==(const BoundVec3 &other) const noexcept {
+        return this->x() == other.x() && this->y() == other.y() && this->z() == other.z();
     }
 };
 


### PR DESCRIPTION
Author's note: I've been meaning to get around to this for awhile. I've finally had some time to implement it.

## Description
Currently, our radialHit function isn't very efficient. With each call, we were calculating the length between the next point of intersection and the sphere center. This is very expensive requiring 10+ floating point operations and a std::sqrt(). We also had many branch predictions, based off whether the radial step transition has occurred or not. Lastly, we were unnecessarily calculating times for 4 separate points of intersection with each call of radialHit. I now propose a simplified version, that is broken down into two cases. Here, a radial step transition is defined as the transition from positive tStepR to negative tStepR. This is necessary since radial voxels are defined from 1, 2, ..., N-1, N, N-1, N-2, ..., 1.

### The Two Cases
1. The radial step transition has not occurred.
2. The radial step transition has occurred.

#### Case 1
In case 1, there are 4 outcomes.
1a. Step to the next inner radial voxel. No radial step transition.
![Screen Shot 2020-05-17 at 5 33 32 PM](https://user-images.githubusercontent.com/37983775/82160599-8e504c00-9864-11ea-8cab-cb356a83bf8c.png)

1b. Tangential hit has occurred, and thus a radial step transition has also occurred.
![Screen Shot 2020-05-17 at 5 34 24 PM](https://user-images.githubusercontent.com/37983775/82160612-a922c080-9864-11ea-86be-48eeac23f707.png)


1c. The next intersection within time bounds is on the "far side" of the current radial voxel. In other words, we've already entered the radial voxel, and now our next intersection is on the "other side" or an exit of the same radial voxel. This also means a radial step transition has occurred.
![Screen Shot 2020-05-17 at 5 34 48 PM](https://user-images.githubusercontent.com/37983775/82160628-b770dc80-9864-11ea-809f-ef5d7f7f4502.png)

1d. Neither ```t < t1 < t_end``` nor ```t2 < t_end``` is true. Set tMaxR to ```numeric_limits::max```.
![Screen Shot 2020-05-17 at 5 35 17 PM](https://user-images.githubusercontent.com/37983775/82160640-c9527f80-9864-11ea-8b6c-3dcd7cdcb0cc.png)

#### Case 2
In case 2, there are 2 outcomes.
2a. If ```intersection_t < t_end```, step to the next outer radial voxel. Since this intersection is with the next outer radial voxel, we are always guaranteed that ```intersection_t > t```.
![Screen Shot 2020-05-17 at 5 36 06 PM](https://user-images.githubusercontent.com/37983775/82160659-e5562100-9864-11ea-9564-e3fd6f0a33ff.png)

2b. ```intersection_t < t_end``` is not true or the next radial voxel entered will be radial voxel zero. Set tMaxR to ```numeric_limits::max```. In the picture below, the dotted circle is radial voxel zero.
![Screen Shot 2020-05-17 at 5 36 39 PM](https://user-images.githubusercontent.com/37983775/82160674-f99a1e00-9864-11ea-9d85-56afb11ab297.png)

### The gist
So now we can separate the logic of these two cases with the following pseudocode:
```
if a radial step transition has occurred:
    check the outcomes in case 2.
else
    check the outcomes in case 1.
```

#### Operation counts
Case 1: (worst case) 9 floating point operations, 4 floating point comparisons, 1 std::sqrt
Case 2: 5 floating point operations, 1 floating point comparison, 1 std::sqrt

#### In other news...
- Add test to ensure that radial voxel 0 is not reached.
- Add two tests for when the sphere is not at the origin.

### Type of change
- [X] Testing
- [X] Optimization

### How Has This Been Tested?

```
  TEST(SphericalCoordinateTraversal, AvoidRaySteppingToRadialVoxelZero) {
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10e3;
        const std::size_t num_radial_sections = 128;
        const std::size_t num_polar_sections = 128;
        const std::size_t num_azimuthal_sections = 128;
        const svr::SphereBound min_bound = {.radial=0.0, .polar=0.0, .azimuthal=0.0};
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=2 * M_PI, .azimuthal=2 * M_PI};
        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_polar_sections, num_azimuthal_sections, sphere_center);
        const double t_begin = 0.0;
        const double t_end = sphere_max_radius * 3;
        const Ray ray(BoundVec3(-984.375, 250.0, -10001.0), FreeVec3(0.0, 0.0, 1.0));
        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
        const std::size_t last_idx = actual_voxels.size() - 1;
        EXPECT_NE(actual_voxels[last_idx].radial, 0);
    }

  TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
        // Given an orthographic ray projection with sufficient time, all rays should enter and exit the sphere.
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10e4;
        const std::size_t num_radial_sections = 64;
        const std::size_t num_polar_sections = 64;
        const std::size_t num_azimuthal_sections = 64;
        const svr::SphereBound min_bound = {.radial=0.0, .polar=0.0, .azimuthal=0.0};
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=2 * M_PI, .azimuthal=2 * M_PI};
        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_polar_sections,
                                           num_azimuthal_sections, sphere_center);
        const double t_begin = 0.0;
        const double t_end = sphere_max_radius * 3;

        const FreeVec3  ray_direction(0.0, 0.0, 1.0);
        double ray_origin_x = -1000.0;
        double ray_origin_y = -1000.0;
        const double ray_origin_z = -(sphere_max_radius + 1.0);

        const double ray_origin_plane_movement = 2000.0 / 30;
        for (std::size_t i = 0; i < 30; ++i) {
            for (std::size_t j = 0; j < 30; ++j) {
                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
                const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
                EXPECT_NE(actual_voxels.size(), 0);
                EXPECT_EQ(actual_voxels[0].radial, 1);
                const std::size_t last = actual_voxels.size() - 1;
                EXPECT_EQ(actual_voxels[last].radial, 1);
                ray_origin_y = (j == 30 - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
            }
            ray_origin_x += ray_origin_plane_movement;
        }
    }
```

### Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Next steps:
- The next computationally-heavy bottleneck functions are the angular hits. These will need to be revised as well.