### PR TITLE
Optimize radial voxel initialization for the common case; add more tests.

### DIFF
--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -589,6 +589,87 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [2, 2, 2, 2]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_ray_begins_past_sphere_origin_one(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([-3.0, 2.4, -3.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [3, 2, 1]
+        expected_theta_voxels = [1, 1, 1]
+        expected_phi_voxels = [2, 2, 2]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_past_sphere_origin_two(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([-4.5, 3.6, -4.5])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [2, 1]
+        expected_theta_voxels = [1, 1]
+        expected_phi_voxels = [2, 2]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_past_sphere_origin_three(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([-6.0, 4.8, -6.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = [1]
+        expected_theta_voxels = [1]
+        expected_phi_voxels = [2]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_begins_past_sphere_origin_four(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([-7.5, 6.0, -7.5])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, t_begin, t_end)
+        expected_radial_voxels = []
+        expected_theta_voxels = []
+        expected_phi_voxels = []
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+
     def test_ray_tangential_hit(self):
         ray_origin = np.array([-5.0, 0.0, 10.0])
         ray_direction = np.array([0.0, 0.0, -1.0])

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -590,8 +590,8 @@ class TestWalkSphericalVolume(unittest.TestCase):
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_past_sphere_origin_one(self):
-        ray_origin = np.array([0.0, 0.0, 0.0])
-        ray_direction = np.array([-3.0, 2.4, -3.0])
+        ray_origin = np.array([-3.0, 2.4, -3.0])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
@@ -610,8 +610,8 @@ class TestWalkSphericalVolume(unittest.TestCase):
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_past_sphere_origin_two(self):
-        ray_origin = np.array([0.0, 0.0, 0.0])
-        ray_direction = np.array([-4.5, 3.6, -4.5])
+        ray_origin = np.array([-4.5, 3.6, -4.5])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
@@ -630,8 +630,8 @@ class TestWalkSphericalVolume(unittest.TestCase):
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_past_sphere_origin_three(self):
-        ray_origin = np.array([0.0, 0.0, 0.0])
-        ray_direction = np.array([-6.0, 4.8, -6.0])
+        ray_origin = np.array([-6.0, 4.8, -6.0])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
@@ -650,8 +650,8 @@ class TestWalkSphericalVolume(unittest.TestCase):
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_past_sphere_origin_four(self):
-        ray_origin = np.array([0.0, 0.0, 0.0])
-        ray_direction = np.array([-7.5, 6.0, -7.5])
+        ray_origin = np.array([-7.5, 6.0, -7.5])
+        ray_direction = np.array([-1.5, 1.2, -1.5])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -416,7 +416,7 @@ namespace svr {
         const bool ray_origin_is_outside_grid = (radial_entrance_voxel == 0);
 
         const std::size_t vector_index = radial_entrance_voxel - !ray_origin_is_outside_grid;
-        const double entry_radius = grid.deltaRadii(vector_index);
+        const double entry_radius = (grid.numRadialSections() - vector_index) * grid.deltaRadius();
         const double entry_radius_squared = grid.deltaRadiiSquared(vector_index);
 
         const FreeVec3 rsv = t_begin == 0.0 ? rsv_begin : grid.sphereCenter() - ray.pointAtParameter(0.0);

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -47,18 +47,14 @@ namespace svr {
                 delta_theta_((max_bound.polar - min_bound.polar) / num_polar_sections),
                 delta_phi_((max_bound.azimuthal - min_bound.azimuthal) / num_azimuthal_sections) {
 
-            delta_radii_.resize(num_radial_sections + 1);
-            double current_delta_radius = delta_radius_ * num_radial_sections;
-            std::generate(delta_radii_.begin(), delta_radii_.end(),
+            double current_delta_radius = max_bound.radial - min_bound.radial;
+            delta_radii_sq_.resize(num_radial_sections + 1);
+            std::generate(delta_radii_sq_.begin(), delta_radii_sq_.end(),
                           [&]() -> double {
                               const double old_delta_radius = current_delta_radius;
                               current_delta_radius -= delta_radius_;
-                              return old_delta_radius;
+                              return old_delta_radius * old_delta_radius;
                           });
-            delta_radii_sq_.resize(num_radial_sections + 1);
-            std::transform(delta_radii_.cbegin(), delta_radii_.cend(), delta_radii_sq_.begin(),
-                           [](double dR) -> double { return dR * dR; });
-
             P_max_polar_.resize(num_polar_sections + 1);
             P_max_azimuthal_.resize(num_azimuthal_sections + 1);
             center_to_polar_bound_vectors_.reserve(num_polar_sections + 1);
@@ -133,13 +129,9 @@ namespace svr {
 
         inline const BoundVec3 &sphereCenter() const noexcept { return this->sphere_center_; }
 
-        inline double deltaRadii(std::size_t i) const noexcept { return this->delta_radii_[i]; }
+        inline double deltaRadius() const noexcept { return delta_radius_; }
 
         inline double deltaRadiiSquared(std::size_t i) const noexcept { return this->delta_radii_sq_[i]; }
-
-        inline const std::vector<double> &deltaRadii() const noexcept { return this->delta_radii_; }
-
-        inline const std::vector<double> &deltaRadiiSquared() const noexcept { return this->delta_radii_sq_; }
 
         inline const LineSegment &pMaxPolar(std::size_t i) const noexcept { return this->P_max_polar_[i]; }
 
@@ -175,9 +167,6 @@ namespace svr {
 
         // 2 * PI divided by X, where X is the number of polar and number of azimuthal sections respectively.
         const double delta_theta_, delta_phi_;
-
-        // The delta radii ranging from 0...num_radial_voxels.
-        std::vector<double> delta_radii_;
 
         // The delta radii squared ranging from 0...num_radial_voxels.
         std::vector<double> delta_radii_sq_;

--- a/cpp/tests/test_SVR.cpp
+++ b/cpp/tests/test_SVR.cpp
@@ -637,6 +637,90 @@ namespace {
         verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
+    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginOne) {
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_polar_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
+        const BoundVec3 ray_origin(-3.0, 2.4, -3.0);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {3, 2, 1};
+        const std::vector<int> expected_theta_voxels = {1, 1, 1};
+        const std::vector<int> expected_phi_voxels = {2, 2, 2};
+        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginTwo) {
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_polar_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
+        const BoundVec3 ray_origin(-4.5, 3.6, -4.5);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {2, 1};
+        const std::vector<int> expected_theta_voxels = {1, 1};
+        const std::vector<int> expected_phi_voxels = {2, 2};
+        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginThree) {
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_polar_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
+        const BoundVec3 ray_origin(-6.0, 4.8, -6.0);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {1};
+        const std::vector<int> expected_theta_voxels = {1};
+        const std::vector<int> expected_phi_voxels = {2};
+        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginFour) {
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_polar_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
+        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
+                                           num_azimuthal_sections, sphere_center);
+        const BoundVec3 ray_origin(-7.5, 6.0, -7.5);
+        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+        const std::vector<int> expected_radial_voxels = {};
+        const std::vector<int> expected_theta_voxels = {};
+        const std::vector<int> expected_phi_voxels = {};
+        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
     TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
@@ -784,40 +868,6 @@ namespace {
         const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
         const std::size_t last_idx = actual_voxels.size() - 1;
         EXPECT_NE(actual_voxels[last_idx].radial, 0);
-    }
-
-    TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExitZAxis) {
-        // Given an orthographic ray projection with sufficient time, all rays should enter and exit the sphere.
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10e4;
-        const std::size_t num_radial_sections = 32;
-        const std::size_t num_polar_sections = 32;
-        const std::size_t num_azimuthal_sections = 32;
-        const svr::SphereBound min_bound = {.radial=0.0, .polar=0.0, .azimuthal=0.0};
-        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=2 * M_PI, .azimuthal=2 * M_PI};
-        const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections, num_polar_sections,
-                                           num_azimuthal_sections, sphere_center);
-        const double t_begin = 0.0;
-        const double t_end = sphere_max_radius * 3;
-
-        const FreeVec3  ray_direction(0.0, 0.0, 1.0);
-        double ray_origin_x = -1000.0;
-        double ray_origin_y = -1000.0;
-        const double ray_origin_z = -(sphere_max_radius + 1.0);
-
-        const double ray_origin_plane_movement = 2000.0 / 30;
-        for (std::size_t i = 0; i < 30; ++i) {
-            for (std::size_t j = 0; j < 30; ++j) {
-                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-                const auto actual_voxels = walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
-                EXPECT_NE(actual_voxels.size(), 0);
-                EXPECT_EQ(actual_voxels[0].radial, 1);
-                const std::size_t last = actual_voxels.size() - 1;
-                EXPECT_EQ(actual_voxels[last].radial, 1);
-                ray_origin_y = (j == 30 - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
-            }
-            ray_origin_x += ray_origin_plane_movement;
-        }
     }
 
     TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {


### PR DESCRIPTION
## Description
The common case is likely to be rays outside the spherical volume. Here we optimize for the uncommon case -- we begin at the inner most radius and work our way outwards. We need to see if there's a simpler way to start from the outermost radial voxel to the innermost.

This is done by using the squared euclidean distance of ```ray.pointAtParameter(t_begin) - sphereCenter()```, and comparing it to the squared radius. While the squared euclidean distance is less than the squared radius, increment the radial voxel.

No functionality has changed.

#### In other news:
- Added a few more tests, which led to an early exit case when the current radial voxel == 0.
- Removed a duplicate test case.



### Type of change

- [X] Optimization
- [X] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

```
TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginOne) {
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10.0;
        const std::size_t num_radial_sections = 4;
        const std::size_t num_polar_sections = 4;
        const std::size_t num_azimuthal_sections = 4;
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
                                           num_azimuthal_sections, sphere_center);
        const BoundVec3 ray_origin(-3.0, 2.4, -3.0);
        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
        const Ray ray(ray_origin, ray_direction);
        const double t_begin = 0.0;
        const double t_end = 30.0;
        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
        const std::vector<int> expected_radial_voxels = {3, 2, 1};
        const std::vector<int> expected_theta_voxels = {1, 1, 1};
        const std::vector<int> expected_phi_voxels = {2, 2, 2};
        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
    }

    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginTwo) {
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10.0;
        const std::size_t num_radial_sections = 4;
        const std::size_t num_polar_sections = 4;
        const std::size_t num_azimuthal_sections = 4;
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
                                           num_azimuthal_sections, sphere_center);
        const BoundVec3 ray_origin(-4.5, 3.6, -4.5);
        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
        const Ray ray(ray_origin, ray_direction);
        const double t_begin = 0.0;
        const double t_end = 30.0;
        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
        const std::vector<int> expected_radial_voxels = {2, 1};
        const std::vector<int> expected_theta_voxels = {1, 1};
        const std::vector<int> expected_phi_voxels = {2, 2};
        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
    }

    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginThree) {
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10.0;
        const std::size_t num_radial_sections = 4;
        const std::size_t num_polar_sections = 4;
        const std::size_t num_azimuthal_sections = 4;
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
                                           num_azimuthal_sections, sphere_center);
        const BoundVec3 ray_origin(-6.0, 4.8, -6.0);
        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
        const Ray ray(ray_origin, ray_direction);
        const double t_begin = 0.0;
        const double t_end = 30.0;
        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
        const std::vector<int> expected_radial_voxels = {1};
        const std::vector<int> expected_theta_voxels = {1};
        const std::vector<int> expected_phi_voxels = {2};
        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
    }

    TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginFour) {
        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
        const double sphere_max_radius = 10.0;
        const std::size_t num_radial_sections = 4;
        const std::size_t num_polar_sections = 4;
        const std::size_t num_azimuthal_sections = 4;
        const svr::SphereBound max_bound = {.radial=sphere_max_radius, .polar=TAU, .azimuthal=TAU};
        const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections, num_polar_sections,
                                           num_azimuthal_sections, sphere_center);
        const BoundVec3 ray_origin(-7.5, 6.0, -7.5);
        const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
        const Ray ray(ray_origin, ray_direction);
        const double t_begin = 0.0;
        const double t_end = 30.0;
        const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
        const std::vector<int> expected_radial_voxels = {};
        const std::vector<int> expected_theta_voxels = {};
        const std::vector<int> expected_phi_voxels = {};
        verifyEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
    }
```


### Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
