### PR TITLE
Documentation, static_cast to avoid implicit cast

### DIFF
--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -507,7 +507,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
       grid.sphereCenter() -
       ray.pointAtParameter(t_begin);  // Ray Sphere Vector.
   const double SED_from_center = rsv_begin.squared_length();
-  std::size_t radial_entrance_voxel = 0;
+  int radial_entrance_voxel = 0;
   const double max_radius_squared = grid.deltaRadiiSquared(0);
 
   while (SED_from_center < grid.deltaRadiiSquared(radial_entrance_voxel)) {
@@ -518,7 +518,8 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
   const std::size_t vector_index =
       radial_entrance_voxel - !ray_origin_is_outside_grid;
   const double entry_radius =
-      (grid.numRadialSections() - vector_index) * grid.deltaRadius();
+      grid.deltaRadius() *
+      static_cast<double>(grid.numRadialSections() - vector_index);
   const double entry_radius_squared = grid.deltaRadiiSquared(vector_index);
 
   const FreeVec3 rsv = t_begin == 0.0

--- a/cpp/tests/ci_tests.cpp
+++ b/cpp/tests/ci_tests.cpp
@@ -292,6 +292,11 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
   }
 }
 
+// Represents the parameters for the CI tests.
+// For example, if ray_squared_count = 64, then 64^2 rays will traverse.
+// Similarly, if voxel_cubed_count = 32, then the grid will be divided into
+// 32^3 voxels. The exception to this is with RandomizedInputs, which uses
+// a random number of sections within bounds [16, Y].
 struct TestParameters {
   std::size_t ray_squared_count;
   std::size_t voxel_cubed_count;
@@ -318,13 +323,13 @@ const std::vector<TestParameters> orthographic_test_parameters = {
     {.ray_squared_count = 1024, .voxel_cubed_count = 32},
 };
 
-TEST(ContinuousIntegration, RandomRayPlacement) {
+TEST(ContinuousIntegration, RandomizedInputs) {
   for (const auto param : random_test_parameters) {
-    printf("   [ RUN      ] %lu^2 Rays in [16, %lu^3] Voxels\n",
+    printf("   [ RUN      ] %lu^2 Rays in [16, %lu^3] Bounded Voxels\n",
            param.ray_squared_count, param.voxel_cubed_count);
     randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
         param.ray_squared_count, param.voxel_cubed_count);
-    printf("   [       OK ] %lu^2 Rays in [16, %lu^3] Voxels\n",
+    printf("   [       OK ] %lu^2 Rays in [16, %lu^3] Bounded Voxels\n",
            param.ray_squared_count, param.voxel_cubed_count);
   }
 }


### PR DESCRIPTION
- Documentation for CI_tests.
- Use static_cast to avoid implicit casts.