### PR TITLE
Unitize time, ray direction. Add CI tests for when ray is within the sphere.

### DIFF
--- a/cpp/benchmarks/benchmark_svr.cpp
+++ b/cpp/benchmarks/benchmark_svr.cpp
@@ -43,10 +43,7 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = sphere_max_radius * 3;
-
-  const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   double ray_origin_x = -1000.0;
   double ray_origin_y = -1000.0;
   const double ray_origin_z = -(sphere_max_radius + 1.0);
@@ -56,7 +53,7 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
     for (std::size_t j = 0; j < X; ++j) {
       const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
       const auto actual_voxels = walkSphericalVolume(
-          Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+          Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
       ray_origin_y =
           (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
     }

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -25,7 +25,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] min_bound,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] max_bound,
                           int num_radial_voxels, int num_polar_voxels, int num_azimuthal_voxels,
-                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center, np.float64_t t_end):
+                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center, np.float64_t t_end = 1.0):
     '''
     Spherical Coordinate Voxel Traversal Algorithm
     Cythonized version of the Spherical Coordinate Voxel Traversal Algorithm.
@@ -38,7 +38,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
            num_polar_voxels: The number of polar voxels.
            num_azimuthal_voxels: The number of azimuthal voxels.
            sphere_center: The 3-dimensional (x,y,z) center of the sphere.
-           t_end: The end time of the ray.
+           t_end: The unitized end time of the ray. Defaulted to the maximum time 1.0
     Returns:
            A numpy array of the spherical voxel coordinates.
            The voxel coordinates are as follows:

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -15,7 +15,7 @@ cdef extern from "../spherical_volume_rendering_util.h" namespace "svr":
                                                double *min_bound, double *max_bound,
                                                size_t num_radial_voxels, size_t num_polar_voxels,
                                                size_t num_azimuthal_voxels, double *sphere_center,
-                                               double t_begin, double t_end)
+                                               double t_end)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -25,21 +25,19 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] min_bound,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] max_bound,
                           int num_radial_voxels, int num_polar_voxels, int num_azimuthal_voxels,
-                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center,
-                          np.float64_t t_begin, np.float64_t t_end):
+                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center, np.float64_t t_end):
     '''
     Spherical Coordinate Voxel Traversal Algorithm
     Cythonized version of the Spherical Coordinate Voxel Traversal Algorithm.
     Arguments:
            ray_origin: The 3-dimensional (x,y,z) origin of the ray.
-           ray_direction: The 3-dimensional (x,y,z) direction of the ray.
+           ray_direction: The 3-dimensional (x,y,z) unit direction of the ray.
            min_bound: The minimum boundary of the sectored sphere in the form (radial, theta, phi).
            max_bound: The maximum boundary of the sectored sphere in the form (radial, theta, phi).
            num_radial_voxels: The number of radial voxels.
            num_polar_voxels: The number of polar voxels.
            num_azimuthal_voxels: The number of azimuthal voxels.
            sphere_center: The 3-dimensional (x,y,z) center of the sphere.
-           t_begin: The beginning time of the ray.
            t_end: The end time of the ray.
     Returns:
            A numpy array of the spherical voxel coordinates.

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -15,7 +15,7 @@ cdef extern from "../spherical_volume_rendering_util.h" namespace "svr":
                                                double *min_bound, double *max_bound,
                                                size_t num_radial_voxels, size_t num_polar_voxels,
                                                size_t num_azimuthal_voxels, double *sphere_center,
-                                               double t_end)
+                                               double max_t)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -25,7 +25,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] min_bound,
                           np.ndarray[np.float64_t, ndim=1, mode="c"] max_bound,
                           int num_radial_voxels, int num_polar_voxels, int num_azimuthal_voxels,
-                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center, np.float64_t t_end = 1.0):
+                          np.ndarray[np.float64_t, ndim=1, mode="c"] sphere_center, np.float64_t max_t = 1.0):
     '''
     Spherical Coordinate Voxel Traversal Algorithm
     Cythonized version of the Spherical Coordinate Voxel Traversal Algorithm.
@@ -38,7 +38,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
            num_polar_voxels: The number of polar voxels.
            num_azimuthal_voxels: The number of azimuthal voxels.
            sphere_center: The 3-dimensional (x,y,z) center of the sphere.
-           t_end: The unitized end time of the ray. Defaulted to the maximum time 1.0
+           max_t: The unitized maximum time of ray traversal. Defaulted to 1.0
     Returns:
            A numpy array of the spherical voxel coordinates.
            The voxel coordinates are as follows:
@@ -63,7 +63,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                                                              &min_bound[0], &max_bound[0],
                                                              num_radial_voxels, num_polar_voxels,
                                                              num_azimuthal_voxels, &sphere_center[0],
-                                                             t_end)
+                                                             max_t)
     cdef np.ndarray cyVoxels = np.empty((voxels.size(), 3), dtype=int)
     for i in range(voxels.size()):
         cyVoxels[i,0] = voxels[i].radial

--- a/cpp/cython/cython_SVR.pyx
+++ b/cpp/cython/cython_SVR.pyx
@@ -63,7 +63,7 @@ def walk_spherical_volume(np.ndarray[np.float64_t, ndim=1, mode="c"] ray_origin,
                                                              &min_bound[0], &max_bound[0],
                                                              num_radial_voxels, num_polar_voxels,
                                                              num_azimuthal_voxels, &sphere_center[0],
-                                                             t_begin, t_end)
+                                                             t_end)
     cdef np.ndarray cyVoxels = np.empty((voxels.size(), 3), dtype=int)
     for i in range(voxels.size()):
         cyVoxels[i,0] = voxels[i].radial

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import cython_SVR
 
-
 class TestWalkSphericalVolume(unittest.TestCase):
     # Verifies correctness of the voxel traversal coordinates.
     def verify_voxels(self, voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels):

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -72,6 +72,103 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_max_t_greater_than_one_and_ray_outside_sphere(self):
+        ray_origin = np.array([-13.0, -13.0, -13.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        max_t = 10.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, max_t)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_max_t_greater_than_one_and_ray_inside_sphere(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        max_t = 10.0
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, max_t)
+        expected_radial_voxels = [4, 3, 2, 1]
+        expected_theta_voxels = [0, 0, 0, 0]
+        expected_phi_voxels = [0, 0, 0, 0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_max_t_halved_and_ray_outside_sphere(self):
+        ray_origin = np.array([-13.0, -13.0, -13.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        max_t = 0.5
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, max_t)
+        expected_radial_voxels = [1, 2, 3, 4, 4]
+        expected_theta_voxels = [2, 2, 2, 2, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_max_t_halved_and_ray_inside_sphere(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        max_t = 0.5
+        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, max_t)
+        expected_radial_voxels = [4, 3, 2, 1]
+        expected_theta_voxels = [0, 0, 0, 0]
+        expected_phi_voxels = [0, 0, 0, 0]
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_max_t_at_or_less_than_zero(self):
+        ray_origin = np.array([0.0, 0.0, 0.0])
+        ray_direction = np.array([1.0, 1.0, 1.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_polar_sections = 4
+        num_azimuthal_sections = 4
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
+        max_t = 0.0
+        v1 = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                                  sphere_center, max_t)
+        max_t = -0.1
+        v2 = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
+                                              num_radial_sections, num_polar_sections, num_azimuthal_sections,
+                                              sphere_center, max_t)
+        self.assertEqual(0, v1.size)
+        self.assertEqual(0, v2.size)
+
     def test_sphere_center_not_at_origin(self):
         ray_origin = np.array([-11.0, -11.0, -11.0])
         ray_direction = np.array([1.0, 1.0, 1.0])

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 import cython_SVR
 
+
 class TestWalkSphericalVolume(unittest.TestCase):
     # Verifies correctness of the voxel traversal coordinates.
     def verify_voxels(self, voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels):
@@ -31,13 +32,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         assert voxels.size == 0
 
     def test_ray_does_not_enter_sphere_tangential_hit(self):
@@ -48,13 +47,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         assert voxels.size == 0
 
     def test_sphere_center_at_origin(self):
@@ -65,13 +62,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -85,13 +80,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -105,13 +98,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [2, 3, 4, 4, 4, 4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 0, 3, 3, 3, 3, 3]
         expected_phi_voxels = [1, 1, 1, 0, 0, 3, 3, 3, 3]
@@ -125,7 +116,6 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
         t_end = 0.5
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
@@ -145,7 +135,6 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
         t_end = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
@@ -165,7 +154,6 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
         t_end = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
@@ -185,13 +173,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 2, 3, 2, 2, 1]
         expected_theta_voxels = [2, 2, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 2, 0, 0]
@@ -205,13 +191,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 3, 0, 0, 0, 0]
         expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
@@ -225,13 +209,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [5, 5, 5, 5, 1, 1, 1, 1]
         expected_phi_voxels = [0, 0, 0, 0, 0, 0, 0, 0]
@@ -245,13 +227,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [0, 0, 0, 0, 0, 0, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -265,13 +245,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
@@ -285,13 +263,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -305,13 +281,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -325,13 +299,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 0, 0, 3, 3, 3]
         expected_phi_voxels = [2, 2, 2, 1, 1, 0, 0, 0, 0, 0]
@@ -345,13 +317,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 1, 2, 2, 1]
         expected_theta_voxels = [2, 1, 1, 0, 0]
         expected_phi_voxels = [1, 1, 1, 0, 0]
@@ -365,13 +335,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
         expected_phi_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
@@ -385,13 +353,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 1, 2, 1, 1]
         expected_theta_voxels = [0, 3, 3, 3, 2]
         expected_phi_voxels = [0, 0, 0, 0, 1]
@@ -405,13 +371,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 3
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 2, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 1, 1, 0, 0]
@@ -425,13 +389,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 3
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
@@ -445,13 +407,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 40
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
                                   18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
                                   33, 34, 35, 36, 37, 38, 39, 40, 40, 39, 38, 37, 36, 35, 34,
@@ -475,13 +435,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 40
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -495,13 +453,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 40
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
@@ -515,13 +471,12 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        1
-        t_end = 1.0
+
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
         expected_phi_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
@@ -535,8 +490,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 0.5
+        t_end = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
@@ -555,13 +509,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [2, 2, 2, 2]
@@ -575,13 +527,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [3, 2, 1]
         expected_theta_voxels = [1, 1, 1]
         expected_phi_voxels = [2, 2, 2]
@@ -595,13 +545,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [2, 1]
         expected_theta_voxels = [1, 1]
         expected_phi_voxels = [2, 2]
@@ -615,13 +563,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1]
         expected_theta_voxels = [1]
         expected_phi_voxels = [2]
@@ -635,13 +581,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = []
         expected_theta_voxels = []
         expected_phi_voxels = []
@@ -655,13 +599,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 2, 2]
@@ -675,13 +617,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 1, 2, 2, 2]
@@ -695,13 +635,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 1
         num_azimuthal_sections = 1
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 2, 1]
         expected_theta_voxels = [0, 0, 0, 0, 0]
         expected_phi_voxels = [0, 0, 0, 0, 0]
@@ -715,13 +653,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 2, 2]
@@ -735,13 +671,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0]
         expected_phi_voxels = [3, 3, 3, 3, 3, 2, 1, 0, 0, 0, 0, 0]
@@ -755,13 +689,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-
-        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         assert voxels.size == 0
 
     def test_avoid_ray_stepping_to_radial_voxel_zero(self):
@@ -772,13 +704,11 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 128
         num_polar_sections = 128
         num_azimuthal_sections = 128
-
-        t_end = sphere_max_radius * 3
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center)
         last_radial_voxel = voxels[voxels[0].size - 1][0]
         assert (last_radial_voxel != 0)
 

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -8,9 +8,10 @@ import unittest
 import numpy as np
 import cython_SVR
 
+
 class TestWalkSphericalVolume(unittest.TestCase):
     # Verifies correctness of the voxel traversal coordinates.
-    def verify_voxels(self, voxels, expected_radial_voxels,  expected_theta_voxels,  expected_phi_voxels):
+    def verify_voxels(self, voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels):
         actual_radial_voxels = []
         actual_theta_voxels = []
         actual_phi_voxels = []
@@ -31,13 +32,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 15.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         assert voxels.size == 0
 
     def test_ray_does_not_enter_sphere_tangential_hit(self):
@@ -48,15 +49,14 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 15.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         assert voxels.size == 0
-
 
     def test_sphere_center_at_origin(self):
         ray_origin = np.array([-13.0, -13.0, -13.0])
@@ -66,16 +66,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [2,2,2,2,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_sphere_center_not_at_origin(self):
@@ -86,16 +86,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [2,2,2,2,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_within_sphere(self):
@@ -106,16 +106,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [2,3,4,4,4,4,3,2,1]
-        expected_theta_voxels = [1,1,1,0,3,3,3,3,3]
-        expected_phi_voxels = [1,1,1,0,0,3,3,3,3]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [2, 3, 4, 4, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [1, 1, 1, 0, 3, 3, 3, 3, 3]
+        expected_phi_voxels = [1, 1, 1, 0, 0, 3, 3, 3, 3]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_within_sphere_and_begin_time_is_not_zero(self):
@@ -127,15 +127,15 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 4
         num_azimuthal_sections = 4
         t_begin = 5.0
-        t_end = 30.0
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [4,3,2,1]
-        expected_theta_voxels = [3,3,3,3]
-        expected_phi_voxels = [0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [4, 3, 2, 1]
+        expected_theta_voxels = [3, 3, 3, 3]
+        expected_phi_voxels = [0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_ends_within_sphere(self):
@@ -146,13 +146,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 10.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 2, 3]
         expected_theta_voxels = [3, 3, 2, 2]
         expected_phi_voxels = [0, 0, 1, 1]
@@ -166,16 +166,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 5.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [2,3,4,4,4]
-        expected_theta_voxels = [1,1,1,0,3]
-        expected_phi_voxels = [1,1,1,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [2, 3, 4, 4, 4]
+        expected_theta_voxels = [1, 1, 1, 0, 3]
+        expected_phi_voxels = [1, 1, 1, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_begins_and_ends_within_sphere_not_centered_at_origin(self):
@@ -186,16 +186,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 5.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [2,3,4,4,4]
-        expected_theta_voxels = [1,1,1,0,3]
-        expected_phi_voxels = [1,1,1,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [2, 3, 4, 4, 4]
+        expected_theta_voxels = [1, 1, 1, 0, 3]
+        expected_phi_voxels = [1, 1, 1, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_slight_offset_in_XY_plane(self):
@@ -206,18 +206,17 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 2, 3, 2, 2, 1]
         expected_theta_voxels = [2, 2, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 2, 2, 2, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
-
 
     def test_ray_direction_travels_along_X_axis(self):
         ray_origin = np.array([-15.0, 0.0, 0.0])
@@ -227,16 +226,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [3,3,3,3,0,0,0,0]
-        expected_phi_voxels = [1,1,1,1,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [3, 3, 3, 3, 0, 0, 0, 0]
+        expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_direction_travels_along_Y_axis(self):
@@ -247,16 +246,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [5,5,5,5,1,1,1,1]
-        expected_phi_voxels = [0,0,0,0,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [5, 5, 5, 5, 1, 1, 1, 1]
+        expected_phi_voxels = [0, 0, 0, 0, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_direction_travels_along_Z_axis(self):
@@ -267,16 +266,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [0,0,0,0,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [0, 0, 0, 0, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_XY_plane(self):
@@ -287,16 +286,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [2,2,2,2,0,0,0,0]
-        expected_phi_voxels = [1,1,1,1,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_XZ_plane(self):
@@ -307,16 +306,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [1,1,1,1,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_YZ_plane(self):
@@ -327,16 +326,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
-        expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [2,2,2,2,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+                                                  sphere_center, t_end)
+        expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
+        expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_dir_neg_Y_positive_XZ(self):
@@ -347,13 +346,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 0, 0, 3, 3, 3]
         expected_phi_voxels = [2, 2, 2, 1, 1, 0, 0, 0, 0, 0]
@@ -367,13 +366,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 1, 2, 2, 1]
         expected_theta_voxels = [2, 1, 1, 0, 0]
         expected_phi_voxels = [1, 1, 1, 0, 0]
@@ -387,13 +386,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
         expected_phi_voxels = [3, 3, 3, 2, 2, 1, 1, 1, 1]
@@ -407,13 +406,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 1, 2, 1, 1]
         expected_theta_voxels = [0, 3, 3, 3, 2]
         expected_phi_voxels = [0, 0, 0, 0, 1]
@@ -427,13 +426,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 3
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 2, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 0, 0]
         expected_phi_voxels = [2, 2, 1, 1, 0, 0]
@@ -447,13 +446,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 3
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [1, 1, 1, 1, 0, 0, 0, 0]
@@ -467,26 +466,26 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 40
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
                                   18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
                                   33, 34, 35, 36, 37, 38, 39, 40, 40, 39, 38, 37, 36, 35, 34,
                                   33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19,
                                   18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-        expected_theta_voxels  = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                                  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        expected_phi_voxels =    [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                                  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        expected_theta_voxels = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        expected_phi_voxels = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_large_number_of_angular_sections(self):
@@ -497,13 +496,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 40
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
         expected_phi_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
@@ -517,13 +516,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 40
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [2, 2, 2, 2, 0, 0, 0, 0]
         expected_phi_voxels = [24, 24, 24, 24, 4, 4, 4, 4]
@@ -537,13 +536,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.01
-        t_end = 50.0
+        1
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 4, 4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
         expected_phi_voxels = [1, 1, 1, 1, 3, 3, 3, 3]
@@ -557,13 +556,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 4.3
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4]
         expected_theta_voxels = [2, 2, 2, 3, 3, 0]
         expected_phi_voxels = [2, 2, 2, 3, 3, 3]
@@ -577,13 +576,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [4, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [2, 2, 2, 2]
@@ -597,13 +596,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [3, 2, 1]
         expected_theta_voxels = [1, 1, 1]
         expected_phi_voxels = [2, 2, 2]
@@ -617,13 +616,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [2, 1]
         expected_theta_voxels = [1, 1]
         expected_phi_voxels = [2, 2]
@@ -637,13 +636,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1]
         expected_theta_voxels = [1]
         expected_phi_voxels = [2]
@@ -657,18 +656,17 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = []
         expected_theta_voxels = []
         expected_phi_voxels = []
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
-
 
     def test_ray_tangential_hit(self):
         ray_origin = np.array([-5.0, 0.0, 10.0])
@@ -678,13 +676,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 2, 2]
@@ -698,13 +696,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 1, 2, 2, 2]
@@ -718,13 +716,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 1
         num_azimuthal_sections = 1
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 2, 1]
         expected_theta_voxels = [0, 0, 0, 0, 0]
         expected_phi_voxels = [0, 0, 0, 0, 0]
@@ -738,13 +736,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 2, 1]
         expected_theta_voxels = [1, 1, 1, 1]
         expected_phi_voxels = [1, 1, 2, 2]
@@ -758,13 +756,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 35.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4, 4, 4, 3, 3, 2, 1]
         expected_theta_voxels = [3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0]
         expected_phi_voxels = [3, 3, 3, 3, 3, 2, 1, 0, 0, 0, 0, 0]
@@ -778,13 +776,13 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 8
         num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 35.0
+
+        t_end = 1.0
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         assert voxels.size == 0
 
     def test_avoid_ray_stepping_to_radial_voxel_zero(self):
@@ -795,15 +793,16 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 128
         num_polar_sections = 128
         num_azimuthal_sections = 128
-        t_begin = 0.0
+
         t_end = sphere_max_radius * 3
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_begin, t_end)
+                                                  sphere_center, t_end)
         last_radial_voxel = voxels[voxels[0].size - 1][0]
-        assert(last_radial_voxel != 0)
+        assert (last_radial_voxel != 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -117,26 +117,6 @@ class TestWalkSphericalVolume(unittest.TestCase):
         expected_phi_voxels = [1, 1, 1, 0, 0, 3, 3, 3, 3]
         self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
-    def test_ray_begins_within_sphere_and_begin_time_is_not_zero(self):
-        ray_origin = np.array([-3.0, 4.0, 5.0])
-        ray_direction = np.array([1.0, -1.0, -1.0])
-        sphere_center = np.array([0.0, 0.0, 0.0])
-        sphere_max_radius = 10.0
-        num_radial_sections = 4
-        num_polar_sections = 4
-        num_azimuthal_sections = 4
-        t_begin = 5.0
-        t_end = 1.0
-        min_bound = np.array([0.0, 0.0, 0.0])
-        max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
-        voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
-                                                  num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
-        expected_radial_voxels = [4, 3, 2, 1]
-        expected_theta_voxels = [3, 3, 3, 3]
-        expected_phi_voxels = [0, 0, 0, 0]
-        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
-
     def test_ray_ends_within_sphere(self):
         ray_origin = np.array([13.0, -15.0, 16.0])
         ray_direction = np.array([-1.5, 1.2, -1.5])
@@ -146,7 +126,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 4
         num_azimuthal_sections = 4
 
-        t_end = 1.0
+        t_end = 0.5
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
@@ -166,7 +146,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 4
         num_azimuthal_sections = 4
 
-        t_end = 1.0
+        t_end = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
@@ -186,7 +166,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 4
         num_azimuthal_sections = 4
 
-        t_end = 1.0
+        t_end = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
@@ -556,7 +536,7 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_polar_sections = 4
         num_azimuthal_sections = 4
 
-        t_end = 1.0
+        t_end = 0.5
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,

--- a/cpp/cython/tests/test_walk_spherical_volume.py
+++ b/cpp/cython/tests/test_walk_spherical_volume.py
@@ -116,12 +116,12 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_end = 0.5
+        max_t = 0.5
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center, max_t)
         expected_radial_voxels = [1, 2, 2, 3]
         expected_theta_voxels = [3, 3, 2, 2]
         expected_phi_voxels = [0, 0, 1, 1]
@@ -135,12 +135,12 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_end = 0.4
+        max_t = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center, max_t)
         expected_radial_voxels = [2, 3, 4, 4, 4]
         expected_theta_voxels = [1, 1, 1, 0, 3]
         expected_phi_voxels = [1, 1, 1, 0, 0]
@@ -154,12 +154,12 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_end = 0.4
+        max_t = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center, max_t)
         expected_radial_voxels = [2, 3, 4, 4, 4]
         expected_theta_voxels = [1, 1, 1, 0, 3]
         expected_phi_voxels = [1, 1, 1, 0, 0]
@@ -490,12 +490,12 @@ class TestWalkSphericalVolume(unittest.TestCase):
         num_radial_sections = 4
         num_polar_sections = 4
         num_azimuthal_sections = 4
-        t_end = 0.4
+        max_t = 0.4
         min_bound = np.array([0.0, 0.0, 0.0])
         max_bound = np.array([sphere_max_radius, 2 * np.pi, 2 * np.pi])
         voxels = cython_SVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound,
                                                   num_radial_sections, num_polar_sections, num_azimuthal_sections,
-                                                  sphere_center, t_end)
+                                                  sphere_center, max_t)
         expected_radial_voxels = [1, 2, 3, 3, 4, 4]
         expected_theta_voxels = [2, 2, 2, 3, 3, 0]
         expected_phi_voxels = [2, 2, 2, 3, 3, 3]

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -4,16 +4,15 @@
 #include "vec3.h"
 
 // Encapsulates the functionality of a ray. This consists of two components, the
-// origin of the ray, and the direction of the ray. To avoid checking for a
+// origin of the ray, and the unit direction of the ray. To avoid checking for a
 // non-zero direction upon each function call, these parameters are initialized
 // upon construction.
 struct Ray final {
-  inline Ray(const BoundVec3 &origin, const FreeVec3 &direction)
+  inline Ray(const BoundVec3 &origin, const UnitVec3 &direction)
       : origin_(origin),
         direction_(direction),
-        unit_direction_(direction),
-        inverse_direction_(FreeVec3(1.0 / direction.x(), 1.0 / direction.y(),
-                                    1.0 / direction.z())),
+        inverse_direction_(FreeVec3(1.0 / direction_.x(), 1.0 / direction_.y(),
+                                    1.0 / direction_.z())),
         NZD_index_(std::abs(direction.x()) > 0.0
                        ? X_DIRECTION
                        : std::abs(direction.y()) > 0.0 ? Y_DIRECTION
@@ -33,7 +32,7 @@ struct Ray final {
   // ray.direction() * (v +/- discriminant), We can simply provide the
   // difference or addition of v and the discriminant.
   inline double timeOfIntersectionAt(double discriminant_v) const noexcept {
-    return this->unit_direction_[NZD_index_] * discriminant_v *
+    return this->direction_[NZD_index_] * discriminant_v *
            this->inverse_direction_[NZD_index_];
   }
 
@@ -45,14 +44,10 @@ struct Ray final {
 
   inline const BoundVec3 &origin() const noexcept { return this->origin_; }
 
-  inline const FreeVec3 &direction() const noexcept { return this->direction_; }
+  inline const UnitVec3 &direction() const noexcept { return this->direction_; }
 
   inline const FreeVec3 &invDirection() const noexcept {
     return this->inverse_direction_;
-  }
-
-  inline const UnitVec3 &unitDirection() const noexcept {
-    return this->unit_direction_;
   }
 
   inline DirectionIndex NonZeroDirectionIndex() const noexcept {
@@ -64,10 +59,7 @@ struct Ray final {
   const BoundVec3 origin_;
 
   // The direction of the ray.
-  const FreeVec3 direction_;
-
-  // The normalized direction of the ray.
-  const UnitVec3 unit_direction_;
+  const UnitVec3 direction_;
 
   // The inverse direction of the ray.
   const FreeVec3 inverse_direction_;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -488,11 +488,11 @@ inline void initializeVoxelBoundarySegments(
 }
 
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
-    const Ray &ray, const svr::SphericalVoxelGrid &grid, double t_begin,
+    const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double t_end) noexcept {
+  t_end *= grid.sphereMaxRadius() * 2.0 + 10e6;
   const FreeVec3 rsv =
-      grid.sphereCenter() -
-      ray.pointAtParameter(0.0);  // Ray Sphere Vector.
+      grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
   int radial_entrance_voxel = 0;
   while (SED_from_center < grid.deltaRadiiSquared(radial_entrance_voxel)) {
@@ -507,7 +507,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
       grid.deltaRadius() *
       static_cast<double>(grid.numRadialSections() - vector_index);
   const double rsvd = rsv.dot(rsv);
-  const double v = rsv.dot(ray.unitDirection().to_free());
+  const double v = rsv.dot(ray.direction().to_free());
   const double rsvd_minus_v_squared = rsvd - v * v;
 
   if (entry_radius_squared <= rsvd_minus_v_squared) {
@@ -656,10 +656,10 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
     double *ray_origin, double *ray_direction, double *min_bound,
     double *max_bound, std::size_t num_radial_voxels,
     std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
-    double *sphere_center, double t_begin, double t_end) noexcept {
+    double *sphere_center, double t_end) noexcept {
   return svr::walkSphericalVolume(
       Ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
-          FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2])),
+          UnitVec3(ray_direction[0], ray_direction[1], ray_direction[2])),
       svr::SphericalVoxelGrid(
           svr::SphereBound{.radial = min_bound[0],
                            .polar = min_bound[1],
@@ -669,7 +669,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
                            .azimuthal = max_bound[2]},
           num_radial_voxels, num_polar_voxels, num_azimuthal_voxels,
           BoundVec3(sphere_center[0], sphere_center[1], sphere_center[2])),
-      t_begin, t_end);
+      t_end);
 }
 // LCOV_EXCL_STOP
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -137,9 +137,7 @@ inline int calculateAngularVoxelIDFromPoints(
     const double d1d2 = (X_p1_diff * X_p1_diff) + (X_p2_diff * X_p2_diff) +
                         (Y_p1_diff * Y_p1_diff) + (Y_p2_diff * Y_p2_diff);
     const double d3 = (X_diff * X_diff) + (Y_diff * Y_diff);
-    if (d1d2 < d3 || svr::isEqual(d1d2, d3)) {
-      return i;
-    }
+    if (d1d2 < d3 || svr::isEqual(d1d2, d3)) return i;
   }
   return i;
 }
@@ -156,14 +154,10 @@ inline int initializeAngularVoxelID(const SphericalVoxelGrid &grid,
                                     const std::vector<LineSegment> &angular_max,
                                     double ray_sphere_2, double grid_sphere_2,
                                     double entry_radius) noexcept {
-  if (number_of_sections == 1) {
-    return 0;
-  }
+  if (number_of_sections == 1) return 0;
   const double SED =
       ray_sphere.x() * ray_sphere.x() + ray_sphere_2 * ray_sphere_2;
-  if (SED == 0.0) {
-    return 0;
-  }
+  if (SED == 0.0) return 0;
   const double r = entry_radius / std::sqrt(SED);
   const double p1 = grid.sphereCenter().x() - ray_sphere.x() * r;
   const double p2 = grid_sphere_2 - ray_sphere_2 * r;
@@ -490,9 +484,8 @@ inline void initializeVoxelBoundarySegments(
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double max_t) noexcept {
-  if (max_t <= 0.0) {
-    return {};
-  }
+  if (max_t <= 0.0) return {};
+
   const FreeVec3 rsv =
       grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
@@ -512,14 +505,10 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
   const double v = rsv.dot(ray.direction().to_free());
   const double rsvd_minus_v_squared = rsvd - v * v;
 
-  if (entry_radius_squared <= rsvd_minus_v_squared) {
-    return {};
-  }
+  if (entry_radius_squared <= rsvd_minus_v_squared) return {};
   const double d = std::sqrt(entry_radius_squared - rsvd_minus_v_squared);
   const double t_ray_exit = ray.timeOfIntersectionAt(v + d);
-  if (t_ray_exit < 0.0) {
-    return {};
-  }
+  if (t_ray_exit < 0.0) return {};
   const double t_ray_entrance = ray.timeOfIntersectionAt(v - d);
   int current_radial_voxel = radial_entrance_voxel + ray_origin_is_outside_grid;
 
@@ -579,9 +568,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
                                 current_polar_voxel, t, max_t);
     const auto azimuthal = azimuthalHit(ray, grid, ray_segment, collinear_times,
                                         current_azimuthal_voxel, t, max_t);
-    if (current_radial_voxel + radial.tStep == 0) {
-      return voxels;
-    }
+    if (current_radial_voxel + radial.tStep == 0) return voxels;
     const auto voxel_intersection =
         minimumIntersection(radial, polar, azimuthal);
     switch (voxel_intersection) {

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -490,6 +490,9 @@ inline void initializeVoxelBoundarySegments(
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double max_t) noexcept {
+  if (max_t <= 0.0) {
+    return {};
+  }
   const FreeVec3 rsv =
       grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
@@ -554,7 +557,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
                     .azimuthal = current_azimuthal_voxel});
 
   double t = t_ray_entrance * ray_origin_is_outside_grid;
-  const double unitized_ray_time = max_t * grid.sphereMaxRadius() * 2.0 +
+  const double unitized_ray_time = max_t * grid.sphereMaxDiameter() +
                                    t_ray_entrance * ray_origin_is_outside_grid;
   max_t = ray_origin_is_outside_grid ? std::min(t_ray_exit, unitized_ray_time)
                                      : unitized_ray_time;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -397,41 +397,37 @@ inline HitParameters azimuthalHit(const Ray &ray,
 //
 // For each case, the following must hold: t < tMax < max_t
 inline VoxelIntersectionType minimumIntersection(
-    const HitParameters &rad_params, const HitParameters &ang_params,
-    const HitParameters &azi_params) noexcept {
-  if (rad_params.within_bounds &&
-      svr::lessThan(rad_params.tMax, ang_params.tMax) &&
-      svr::lessThan(rad_params.tMax, azi_params.tMax)) {
+    const HitParameters &radial, const HitParameters &polar,
+    const HitParameters &azimuthal) noexcept {
+  if (!radial.within_bounds && !polar.within_bounds &&
+      !azimuthal.within_bounds) {
+    return VoxelIntersectionType::None;
+  }
+  const bool RP_eq = svr::isEqual(radial.tMax, polar.tMax);
+  const bool RA_eq = svr::isEqual(radial.tMax, azimuthal.tMax);
+  if (radial.within_bounds && radial.tMax < polar.tMax && !RP_eq &&
+      radial.tMax < azimuthal.tMax && !RA_eq) {
     return VoxelIntersectionType::Radial;
   }
-  if (ang_params.within_bounds &&
-      svr::lessThan(ang_params.tMax, rad_params.tMax) &&
-      svr::lessThan(ang_params.tMax, azi_params.tMax)) {
+  const bool PA_eq = svr::isEqual(polar.tMax, azimuthal.tMax);
+  if (polar.within_bounds && polar.tMax < radial.tMax && !RP_eq &&
+      polar.tMax < azimuthal.tMax && !PA_eq) {
     return VoxelIntersectionType::Polar;
   }
-  if (azi_params.within_bounds &&
-      svr::lessThan(azi_params.tMax, ang_params.tMax) &&
-      svr::lessThan(azi_params.tMax, rad_params.tMax)) {
+  if (azimuthal.within_bounds && azimuthal.tMax < polar.tMax && !PA_eq &&
+      azimuthal.tMax < radial.tMax && !RA_eq) {
     return VoxelIntersectionType::Azimuthal;
   }
-  if (rad_params.within_bounds &&
-      svr::isEqual(rad_params.tMax, ang_params.tMax) &&
-      isEqual(rad_params.tMax, azi_params.tMax)) {
+  if (radial.within_bounds && RP_eq && RA_eq) {
     return VoxelIntersectionType::RadialPolarAzimuthal;
   }
-  if (azi_params.within_bounds &&
-      svr::isEqual(azi_params.tMax, ang_params.tMax)) {
+  if (azimuthal.within_bounds && PA_eq) {
     return VoxelIntersectionType::PolarAzimuthal;
   }
-  if (rad_params.within_bounds &&
-      svr::isEqual(ang_params.tMax, rad_params.tMax)) {
+  if (radial.within_bounds && RP_eq) {
     return VoxelIntersectionType::RadialPolar;
   }
-  if (rad_params.within_bounds &&
-      svr::isEqual(rad_params.tMax, azi_params.tMax)) {
-    return VoxelIntersectionType::RadialAzimuthal;
-  }
-  return VoxelIntersectionType::None;
+  return VoxelIntersectionType::RadialAzimuthal;
 }
 
 // Initialize an array of values representing the points of intersection between

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -553,8 +553,9 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
                     .polar = current_polar_voxel,
                     .azimuthal = current_azimuthal_voxel});
 
-  const double unitized_ray_time =
-      t_end * grid.sphereMaxRadius() * 2.0 + t_ray_entrance;
+  double t = t_ray_entrance * ray_origin_is_outside_grid;
+  const double unitized_ray_time = t_end * grid.sphereMaxRadius() * 2.0 +
+                                   t_ray_entrance * ray_origin_is_outside_grid;
   t_end = ray_origin_is_outside_grid ? std::min(t_ray_exit, unitized_ray_time)
                                      : unitized_ray_time;
 
@@ -567,7 +568,6 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
   RadialHitMetadata rh_metadata;
   rh_metadata.updatePreviousRadialVoxel(current_radial_voxel);
   RaySegment ray_segment(t_end, ray);
-  double t = ray_origin_is_outside_grid ? t_ray_entrance : 0.0;
   while (true) {
     const auto radial = radialHit(ray, grid, rh_metadata, current_radial_voxel,
                                   v, rsvd_minus_v_squared, t, t_end);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -511,7 +511,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
                                         current_azimuthal_voxel, t, max_t);
     if (current_radial_voxel + radial.tStep == 0 ||
         (radial.tMax == DOUBLE_MAX && polar.tMax == DOUBLE_MAX &&
-         radial.tMax == DOUBLE_MAX)) {
+         azimuthal.tMax == DOUBLE_MAX)) {
       return voxels;
     }
     const auto voxel_intersection =

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -142,7 +142,7 @@ inline int calculateAngularVoxelIDFromPoints(
   return i;
 }
 
-// Initializes an angular voxel ID. For polar initializations=, *_2 represents
+// Initializes an angular voxel ID. For polar initialization, *_2 represents
 // the y-plane. For azimuthal initialization, it represents the z-plane. If the
 // number of sections is 1 or the squared euclidean distance of the ray_sphere
 // vector in the given plane is zero, the voxel ID is set to 0. Otherwise, we
@@ -322,14 +322,14 @@ inline HitParameters polarHit(const Ray &ray,
                               int current_polar_voxel, double t,
                               double max_t) noexcept {
   // Calculate the voxel boundary vectors.
-  const FreeVec3 p_one(grid.pMaxPolar(current_polar_voxel).P1,
-                       grid.pMaxPolar(current_polar_voxel).P2, 0.0);
-  const FreeVec3 p_two(grid.pMaxPolar(current_polar_voxel + 1).P1,
-                       grid.pMaxPolar(current_polar_voxel + 1).P2, 0.0);
+  const BoundVec3 p_one(grid.pMaxPolar(current_polar_voxel).P1,
+                        grid.pMaxPolar(current_polar_voxel).P2, 0.0);
+  const BoundVec3 p_two(grid.pMaxPolar(current_polar_voxel + 1).P1,
+                        grid.pMaxPolar(current_polar_voxel + 1).P2, 0.0);
   const BoundVec3 *u_min = &grid.centerToPolarBound(current_polar_voxel);
   const BoundVec3 *u_max = &grid.centerToPolarBound(current_polar_voxel + 1);
-  const FreeVec3 w_min = p_one - FreeVec3(ray_segment.P1());
-  const FreeVec3 w_max = p_two - FreeVec3(ray_segment.P1());
+  const FreeVec3 w_min = p_one - ray_segment.P1();
+  const FreeVec3 w_max = p_two - ray_segment.P1();
   const double perp_uv_min = u_min->x() * ray_segment.vector().y() -
                              u_min->y() * ray_segment.vector().x();
   const double perp_uv_max = u_max->x() * ray_segment.vector().y() -
@@ -357,16 +357,16 @@ inline HitParameters azimuthalHit(const Ray &ray,
                                   int current_azimuthal_voxel, double t,
                                   double max_t) noexcept {
   // Calculate the voxel boundary vectors.
-  const FreeVec3 p_one(grid.pMaxAzimuthal(current_azimuthal_voxel).P1, 0.0,
-                       grid.pMaxAzimuthal(current_azimuthal_voxel).P2);
-  const FreeVec3 p_two(grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P1, 0.0,
-                       grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P2);
+  const BoundVec3 p_one(grid.pMaxAzimuthal(current_azimuthal_voxel).P1, 0.0,
+                        grid.pMaxAzimuthal(current_azimuthal_voxel).P2);
+  const BoundVec3 p_two(grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P1, 0.0,
+                        grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P2);
   const BoundVec3 *u_min =
       &grid.centerToAzimuthalBound(current_azimuthal_voxel);
   const BoundVec3 *u_max =
       &grid.centerToAzimuthalBound(current_azimuthal_voxel + 1);
-  const FreeVec3 w_min = p_one - FreeVec3(ray_segment.P1());
-  const FreeVec3 w_max = p_two - FreeVec3(ray_segment.P1());
+  const FreeVec3 w_min = p_one - ray_segment.P1();
+  const FreeVec3 w_max = p_two - ray_segment.P1();
   const double perp_uv_min = u_min->x() * ray_segment.vector().z() -
                              u_min->z() * ray_segment.vector().x();
   const double perp_uv_max = u_max->x() * ray_segment.vector().z() -

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -490,7 +490,6 @@ inline void initializeVoxelBoundarySegments(
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double t_end) noexcept {
-  t_end *= grid.sphereMaxRadius() * 2.0 + 10e6;
   const FreeVec3 rsv =
       grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
@@ -519,6 +518,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
     return {};
   }
   const double t_ray_entrance = ray.timeOfIntersectionAt(v - d);
+  t_end = (t_end * grid.sphereMaxRadius() * 2.0) + t_ray_entrance;
 
   int current_radial_voxel = radial_entrance_voxel + ray_origin_is_outside_grid;
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -485,7 +485,6 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double max_t) noexcept {
   if (max_t <= 0.0) return {};
-
   const FreeVec3 rsv =
       grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
@@ -575,9 +574,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
       case Radial: {
         t = radial.tMax;
         current_radial_voxel += radial.tStep;
-        if (rh_metadata.previousRadialVoxel() == current_radial_voxel) {
-          continue;
-        }
+        if (rh_metadata.previousRadialVoxel() == current_radial_voxel) continue;
         break;
       }
       case Polar: {

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -17,12 +17,12 @@ struct SphericalVoxel {
 };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the
-// ray over the spherical voxel grid provided. t_end is the unitized time at
-// which the ray traversal ends. Returns a vector of the spherical coordinate
+// ray over the spherical voxel grid provided. max_t is the maximum unitized time at
+// until which the ray traverses. Returns a vector of the spherical coordinate
 // voxels traversed.
-// todo: Explain t_end.
+// todo: Explain max_t.
 std::vector<SphericalVoxel> walkSphericalVolume(
-    const Ray &ray, const svr::SphericalVoxelGrid &grid, double t_end) noexcept;
+    const Ray &ray, const svr::SphericalVoxelGrid &grid, double max_t) noexcept;
 
 // Simplified parameters to Cythonize the function; implementation remains the
 // same as above.
@@ -30,7 +30,7 @@ std::vector<SphericalVoxel> walkSphericalVolume(
     double *ray_origin, double *ray_direction, double *min_bound,
     double *max_bound, std::size_t num_radial_voxels,
     std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
-    double *sphere_center, double t_end) noexcept;
+    double *sphere_center, double max_t) noexcept;
 
 }  // namespace svr
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -23,7 +23,7 @@ struct SphericalVoxel {
 // function: ray_travel_duration = time_to_entrance + sphere.diameter() * max_t
 // If the ray origin is within the sphere, then time_to_entrance is 0. Its
 // expected values are within bounds [0.0, 1.0]. For example, if max_t <= 0.0,
-// then no voxels will be traversed. If max_t == 1.0, then the entire sphere
+// then no voxels will be traversed. If max_t >= 1.0, then the entire sphere
 // will be traversed.
 std::vector<SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid, double max_t) noexcept;

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -17,10 +17,13 @@ struct SphericalVoxel {
 };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the
-// ray over the spherical voxel grid provided. max_t is the maximum unitized time at
-// until which the ray traverses. Returns a vector of the spherical coordinate
-// voxels traversed.
-// todo: Explain max_t.
+// ray with unit direction over the spherical voxel grid provided. Returns a
+// vector of the spherical coordinate voxels traversed. max_t is the unitized
+// time for which the ray may travel. It is used in a linear function and will
+// be multiplied by the sphere's diameter to determine travel duration. Its
+// expected values are within bounds [0.0, 1.0]. For example, if max_t <= 0.0,
+// then no voxels will be traversed. If max_t == 1.0, then the entire sphere
+// will be traversed.
 std::vector<SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid, double max_t) noexcept;
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -20,6 +20,7 @@ struct SphericalVoxel {
 // ray over the spherical voxel grid provided. t_end is the unitized time at
 // which the ray traversal ends. Returns a vector of the spherical coordinate
 // voxels traversed.
+// todo: Explain t_end.
 std::vector<SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid, double t_end) noexcept;
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -17,13 +17,11 @@ struct SphericalVoxel {
 };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the
-// ray over the spherical voxel grid provided. t_begin is the time the ray
-// begins, and t_end is the time at which the ray ends. It does not assumes the
-// ray direction is normalized. Returns a vector of the spherical coordinate
+// ray over the spherical voxel grid provided. t_end is the unitized time at
+// which the ray traversal ends. Returns a vector of the spherical coordinate
 // voxels traversed.
 std::vector<SphericalVoxel> walkSphericalVolume(
-    const Ray &ray, const svr::SphericalVoxelGrid &grid, double t_begin,
-    double t_end) noexcept;
+    const Ray &ray, const svr::SphericalVoxelGrid &grid, double t_end) noexcept;
 
 // Simplified parameters to Cythonize the function; implementation remains the
 // same as above.
@@ -31,7 +29,7 @@ std::vector<SphericalVoxel> walkSphericalVolume(
     double *ray_origin, double *ray_direction, double *min_bound,
     double *max_bound, std::size_t num_radial_voxels,
     std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
-    double *sphere_center, double t_begin, double t_end) noexcept;
+    double *sphere_center, double t_end) noexcept;
 
 }  // namespace svr
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -19,8 +19,9 @@ struct SphericalVoxel {
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the
 // ray with unit direction over the spherical voxel grid provided. Returns a
 // vector of the spherical coordinate voxels traversed. max_t is the unitized
-// time for which the ray may travel. It is used in a linear function and will
-// be multiplied by the sphere's diameter to determine travel duration. Its
+// time for which the ray may travel. It is used in the following linear
+// function: ray_travel_duration = time_to_entrance + sphere.diameter() * max_t
+// If the ray origin is within the sphere, then time_to_entrance is 0. Its
 // expected values are within bounds [0.0, 1.0]. For example, if max_t <= 0.0,
 // then no voxels will be traversed. If max_t == 1.0, then the entire sphere
 // will be traversed.

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -46,6 +46,7 @@ struct SphericalVoxelGrid {
         num_azimuthal_sections_(num_azimuthal_sections),
         sphere_center_(sphere_center),
         sphere_max_radius_(max_bound.radial),
+        sphere_max_diameter_(sphere_max_radius_ * 2.0),
         delta_radius_((max_bound.radial - min_bound.radial) /
                       num_radial_sections),
         delta_theta_((max_bound.polar - min_bound.polar) / num_polar_sections),
@@ -152,6 +153,10 @@ struct SphericalVoxelGrid {
     return this->sphere_max_radius_;
   }
 
+  inline double sphereMaxDiameter() const noexcept {
+    return this->sphere_max_diameter_;
+  }
+
   inline const BoundVec3 &sphereCenter() const noexcept {
     return this->sphere_center_;
   }
@@ -206,6 +211,9 @@ struct SphericalVoxelGrid {
 
   // The maximum radius of the sphere.
   const double sphere_max_radius_;
+
+  // The maximum diamater of the sphere.
+  const double sphere_max_diameter_;
 
   // The maximum sphere radius divided by the number of radial sections.
   const double delta_radius_;

--- a/cpp/tests/continuous_integration_tests.cpp
+++ b/cpp/tests/continuous_integration_tests.cpp
@@ -76,7 +76,8 @@ bool checkVoxelBounds(const Ray& ray,
 // the next radial voxel is current+1, current-1, or current+0.
 // Returns false if the checks did not pass.
 bool checkRadialVoxelOrdering(
-    const Ray& ray, const std::vector<svr::SphericalVoxel>& actual_voxels) {
+    const Ray& ray, const std::vector<svr::SphericalVoxel>& actual_voxels,
+    bool traverses_entire_sphere) {
   const auto it = std::adjacent_find(
       actual_voxels.cbegin(), actual_voxels.cend(),
       [](const svr::SphericalVoxel& v1, const svr::SphericalVoxel& v2) {
@@ -100,23 +101,25 @@ bool checkRadialVoxelOrdering(
     printRayData(ray);
     return false;
   }
-  EXPECT_FALSE(actual_voxels.empty());
-  if (actual_voxels.empty()) {
-    printf("\nNo intersection with sphere at all.");
-    printRayData(ray);
-    return false;
-  }
-  const std::size_t last = actual_voxels.size() - 1;
-  EXPECT_TRUE(actual_voxels[0].radial == 1);
-  EXPECT_TRUE(actual_voxels[last].radial == 1);
-  if (actual_voxels[0].radial != 1 || actual_voxels[last].radial != 1) {
-    printf("\nDid not complete entire traversal.");
-    const auto first_voxel = actual_voxels[0];
-    const auto last_voxel = actual_voxels[last];
-    printRayData(ray);
-    printVoxelInformation(first_voxel, "Entrance Voxel.");
-    printVoxelInformation(last_voxel, "Exit Voxel");
-    return false;
+  if (traverses_entire_sphere) {
+    EXPECT_FALSE(actual_voxels.empty());
+    if (actual_voxels.empty()) {
+      printf("\nNo intersection with sphere at all.");
+      printRayData(ray);
+      return false;
+    }
+    const std::size_t last = actual_voxels.size() - 1;
+    EXPECT_TRUE(actual_voxels[0].radial == 1);
+    EXPECT_TRUE(actual_voxels[last].radial == 1);
+    if (actual_voxels[0].radial != 1 || actual_voxels[last].radial != 1) {
+      printf("\nDid not complete entire traversal.");
+      const auto first_voxel = actual_voxels[0];
+      const auto last_voxel = actual_voxels[last];
+      printRayData(ray);
+      printVoxelInformation(first_voxel, "Entrance Voxel.");
+      printVoxelInformation(last_voxel, "Exit Voxel");
+      return false;
+    }
   }
   return true;
 }
@@ -208,9 +211,10 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
     for (std::size_t j = 0; j < X; ++j) {
       const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
       const Ray ray(ray_origin, ray_direction);
-      const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+      const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
       ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, Y, Y, Y) &&
-                  checkRadialVoxelOrdering(ray, actual_voxels) &&
+                  checkRadialVoxelOrdering(ray, actual_voxels,
+                                           /*traverses_entire_sphere=*/true) &&
                   checkAngularVoxelOrdering(ray, actual_voxels));
       ray_origin_y =
           (j == X - 1) ? -1000.0 : ray_origin_y + ray_origin_plane_movement;
@@ -266,10 +270,49 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
     }
     std::uniform_real_distribution<double> dist2(1.0, 3.0);
     const Ray ray(ray_origin, UnitVec3(dist2(mt), dist2(mt), dist2(mt)));
-    const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+    const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
     ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, num_radial_sections,
                                  num_polar_sections, num_azimuthal_sections) &&
-                checkRadialVoxelOrdering(ray, actual_voxels) &&
+                checkRadialVoxelOrdering(ray, actual_voxels,
+                                         /*traverses_entire_sphere=*/true) &&
+                checkAngularVoxelOrdering(ray, actual_voxels));
+  }
+}
+
+// Similar to randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels, but
+// the ray origin is within the sphere. The ray origin is placed within bounds
+// [10,000.0, 10,000.0) and the ray direction is within bounds [10.0, 10.0).
+void inline randomRayPlacementWithinSphere(const std::size_t X,
+                                           const std::size_t Y) noexcept {
+  std::default_random_engine rd(time(nullptr));
+  std::mt19937 mt(rd());
+  EXPECT_GT(Y, 24);
+  std::uniform_int_distribution<int> num_sections(16, Y);
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10e6;
+  const std::size_t num_radial_sections = num_sections(mt);
+  const std::size_t num_polar_sections = num_sections(mt);
+  const std::size_t num_azimuthal_sections = num_sections(mt);
+  const svr::SphereBound min_bound = {
+      .radial = 0.0, .polar = 0.0, .azimuthal = 0.0};
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = 2 * M_PI, .azimuthal = 2 * M_PI};
+  const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+
+  std::uniform_real_distribution<double> dist1(-10000.0, 10000.0);
+  std::uniform_real_distribution<double> dist2(-10.0, 10.0);
+  std::uniform_real_distribution<double> dist3(-0.1, 1.1);
+  for (int i = 0; i < X * X; ++i) {
+    BoundVec3 ray_origin(dist1(mt), dist1(mt), dist1(mt));
+    const Ray ray(ray_origin, UnitVec3(dist2(mt), dist2(mt), dist2(mt)));
+    const double max_t = dist3(mt);
+    const auto actual_voxels = walkSphericalVolume(ray, grid, max_t);
+    ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, num_radial_sections,
+                                 num_polar_sections, num_azimuthal_sections) &&
+                checkRadialVoxelOrdering(ray, actual_voxels,
+                                         /*traverses_entire_sphere=*/false) &&
                 checkAngularVoxelOrdering(ray, actual_voxels));
   }
 }
@@ -304,6 +347,17 @@ const std::vector<TestParameters> orthographic_test_parameters = {
     {.ray_squared_count = 512, .voxel_cubed_count = 32},
     {.ray_squared_count = 1024, .voxel_cubed_count = 32},
 };
+
+TEST(ContinuousIntegration, RayWithinSphereRandomizedInputs) {
+  for (const auto param : random_test_parameters) {
+    printf("   [ RUN      ] %lu^2 Rays in [16, %lu]^3 Voxels\n",
+           param.ray_squared_count, param.voxel_cubed_count);
+    randomRayPlacementWithinSphere(param.ray_squared_count,
+                                   param.voxel_cubed_count);
+    printf("   [       OK ] %lu^2 Rays in [16, %lu]^3 Voxels\n",
+           param.ray_squared_count, param.voxel_cubed_count);
+  }
+}
 
 TEST(ContinuousIntegration, RandomizedInputs) {
   for (const auto param : random_test_parameters) {

--- a/cpp/tests/continuous_integration_tests.cpp
+++ b/cpp/tests/continuous_integration_tests.cpp
@@ -228,8 +228,8 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
 // then used, and the other two origin values are randomly chosen from a value
 // within bounds [-10,000.0, 10,000.0]. The number of sections for each voxel
 // type is bounded by [16, Y];
-void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
-    const std::size_t X, const std::size_t Y) noexcept {
+void inline randomRayPlacementOutsideSphere(const std::size_t X,
+                                            const std::size_t Y) noexcept {
   std::default_random_engine rd(time(nullptr));
   std::mt19937 mt(rd());
   EXPECT_GT(Y, 24);
@@ -279,7 +279,7 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
   }
 }
 
-// Similar to randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels, but
+// Similar to randomRayPlacementOutsideSphere, but
 // the ray origin is within the sphere. The ray origin is placed within bounds
 // [10,000.0, 10,000.0) and the ray direction is within bounds [10.0, 10.0).
 void inline randomRayPlacementWithinSphere(const std::size_t X,
@@ -348,7 +348,7 @@ const std::vector<TestParameters> orthographic_test_parameters = {
     {.ray_squared_count = 1024, .voxel_cubed_count = 32},
 };
 
-TEST(ContinuousIntegration, RayWithinSphereRandomizedInputs) {
+TEST(ContinuousIntegration, RayInsideSphereRandomizedInputs) {
   for (const auto param : random_test_parameters) {
     printf("   [ RUN      ] %lu^2 Rays in [16, %lu]^3 Voxels\n",
            param.ray_squared_count, param.voxel_cubed_count);
@@ -359,12 +359,12 @@ TEST(ContinuousIntegration, RayWithinSphereRandomizedInputs) {
   }
 }
 
-TEST(ContinuousIntegration, RandomizedInputs) {
+TEST(ContinuousIntegration, RayOutsideSphereRandomizedInputs) {
   for (const auto param : random_test_parameters) {
     printf("   [ RUN      ] %lu^2 Rays in [16, %lu]^3 Voxels\n",
            param.ray_squared_count, param.voxel_cubed_count);
-    randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
-        param.ray_squared_count, param.voxel_cubed_count);
+    randomRayPlacementOutsideSphere(param.ray_squared_count,
+                                    param.voxel_cubed_count);
     printf("   [       OK ] %lu^2 Rays in [16, %lu]^3 Voxels\n",
            param.ray_squared_count, param.voxel_cubed_count);
   }

--- a/cpp/tests/continuous_integration_tests.cpp
+++ b/cpp/tests/continuous_integration_tests.cpp
@@ -198,10 +198,9 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = sphere_max_radius * 3;
+  const double t_end = 1.0;
 
-  const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   double ray_origin_x = -1000.0;
   double ray_origin_y = -1000.0;
   const double ray_origin_z = -(sphere_max_radius + 1.0);
@@ -211,7 +210,7 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
     for (std::size_t j = 0; j < X; ++j) {
       const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
       const Ray ray(ray_origin, ray_direction);
-      const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+      const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
       ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, Y, Y, Y) &&
                   checkRadialVoxelOrdering(ray, actual_voxels) &&
                   checkAngularVoxelOrdering(ray, actual_voxels));
@@ -245,12 +244,9 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = sphere_max_radius * 100;
-
+  const double t_end = 1.0;
   std::uniform_int_distribution<int> ray_major_axis_distribution(1, 3);
   BoundVec3 ray_origin;
-  FreeVec3 ray_direction;
   const double chosen_axis = ray_major_axis_distribution(mt);
   if (chosen_axis == 1) {
     ray_origin.x() = -(sphere_max_radius + 1.0);
@@ -272,8 +268,8 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
       ray_origin.y() = dist1(mt);
     }
     std::uniform_real_distribution<double> dist2(1.0, 3.0);
-    const Ray ray(ray_origin, FreeVec3(dist2(mt), dist2(mt), dist2(mt)));
-    const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+    const Ray ray(ray_origin, UnitVec3(dist2(mt), dist2(mt), dist2(mt)));
+    const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
     ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, num_radial_sections,
                                  num_polar_sections, num_azimuthal_sections) &&
                 checkRadialVoxelOrdering(ray, actual_voxels) &&

--- a/cpp/tests/continuous_integration_tests.cpp
+++ b/cpp/tests/continuous_integration_tests.cpp
@@ -198,8 +198,6 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_end = 1.0;
-
   const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   double ray_origin_x = -1000.0;
   double ray_origin_y = -1000.0;
@@ -210,7 +208,7 @@ void inline orthographicTraverseXSquaredRaysinYCubedVoxels(
     for (std::size_t j = 0; j < X; ++j) {
       const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
       const Ray ray(ray_origin, ray_direction);
-      const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+      const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
       ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, Y, Y, Y) &&
                   checkRadialVoxelOrdering(ray, actual_voxels) &&
                   checkAngularVoxelOrdering(ray, actual_voxels));
@@ -244,7 +242,6 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_end = 1.0;
   std::uniform_int_distribution<int> ray_major_axis_distribution(1, 3);
   BoundVec3 ray_origin;
   const double chosen_axis = ray_major_axis_distribution(mt);
@@ -269,7 +266,7 @@ void inline randomRayPlacementTraverseXSquaredRaysInYBoundedCubedVoxels(
     }
     std::uniform_real_distribution<double> dist2(1.0, 3.0);
     const Ray ray(ray_origin, UnitVec3(dist2(mt), dist2(mt), dist2(mt)));
-    const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+    const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
     ASSERT_TRUE(checkVoxelBounds(ray, actual_voxels, num_radial_sections,
                                  num_polar_sections, num_azimuthal_sections) &&
                 checkRadialVoxelOrdering(ray, actual_voxels) &&

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -600,7 +600,7 @@ TEST(SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
   const UnitVec3 ray_direction(1.3, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.5);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -107,7 +107,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal, RayEndsWithinSphere) {
+TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
@@ -121,7 +121,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 ray_origin(13.0, -15.0, 16.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.5);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
   const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
@@ -129,7 +129,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayEndsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
+TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
@@ -143,7 +143,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
   const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -151,7 +151,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal,
+TEST(SphericalCoordinateTraversal,
      RayBeginsAndEndsWithinSphereNotCenteredAtOrigin) {
   const BoundVec3 sphere_center(2.0, 3.0, 2.0);
   const double sphere_max_radius = 10.0;
@@ -166,7 +166,7 @@ TEST(DISABLED_SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-1.0, 7.0, 7.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -585,7 +585,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal,
+TEST(SphericalCoordinateTraversal,
      RayBeginsInOutermostRadiusAndEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
@@ -600,7 +600,7 @@ TEST(DISABLED_SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
   const UnitVec3 ray_direction(1.3, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.5);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -114,30 +114,6 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(SphericalCoordinateTraversal, RayBeginsWithinSphereAndTimeBeginIsNotZero) {
-  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-  const double sphere_max_radius = 10.0;
-  const std::size_t num_radial_sections = 4;
-  const std::size_t num_polar_sections = 4;
-  const std::size_t num_azimuthal_sections = 4;
-  const svr::SphereBound max_bound = {
-      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
-  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
-                                     num_polar_sections, num_azimuthal_sections,
-                                     sphere_center);
-  const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
-  const FreeVec3 ray_direction(1.0, -1.0, -1.0);
-  const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 5.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
-  const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
-  const std::vector<int> expected_theta_voxels = {3, 3, 3, 3};
-  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
-  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
-                    expected_theta_voxels, expected_phi_voxels);
-}
-
 TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
@@ -653,30 +629,6 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
-  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
-                    expected_theta_voxels, expected_phi_voxels);
-}
-
-TEST(SphericalCoordinateTraversal, TimeBeginIsNotZero) {
-  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-  const double sphere_max_radius = 10.0;
-  const std::size_t num_radial_sections = 4;
-  const std::size_t num_polar_sections = 4;
-  const std::size_t num_azimuthal_sections = 4;
-  const svr::SphereBound max_bound = {
-      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
-  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
-                                     num_polar_sections, num_azimuthal_sections,
-                                     sphere_center);
-  const BoundVec3 ray_origin(-15.0, 15.0, 15.0);
-  const FreeVec3 ray_direction(1.0, -1.0, -1.0);
-  const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.01;
-  const double t_end = 50.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
-  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
-  const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
-  const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 3, 3, 3, 3};
   verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                     expected_theta_voxels, expected_phi_voxels);
 }

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -62,7 +62,7 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
   const BoundVec3 ray_origin(3.0, 3.0, 3.0);
   const UnitVec3 ray_direction(-2.0, -1.3, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -80,7 +80,7 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphereTangentialHit) {
   const BoundVec3 ray_origin(-10.0, -10.0, 0.0);
   const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -99,7 +99,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3, 3, 3, 3, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0, 3, 3, 3, 3};
@@ -121,7 +121,7 @@ TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 ray_origin(13.0, -15.0, 16.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.5);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.5);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
   const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
@@ -143,7 +143,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
   const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.4);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -166,7 +166,7 @@ TEST(SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-1.0, 7.0, 7.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.4);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -188,7 +188,7 @@ TEST(SphericalCoordinateTraversal, SphereCenteredAtOrigin) {
   const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -210,7 +210,7 @@ TEST(SphericalCoordinateTraversal, SphereNotCenteredAtOrigin) {
   const BoundVec3 ray_origin(-11.0, -11.0, -11.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -233,7 +233,7 @@ TEST(SphericalCoordinateTraversal, RaySlightOffsetInXYPlane) {
   const UnitVec3 ray_direction(1.0, 1.5, 1.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 2, 0, 0};
@@ -255,7 +255,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongXAxis) {
   const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
   const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 3, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -277,7 +277,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongYAxis) {
   const BoundVec3 ray_origin(0.0, -15.0, 0.0);
   const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {5, 5, 5, 5, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -299,7 +299,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongZAxis) {
   const BoundVec3 ray_origin(0.0, 0.0, -15.0);
   const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -321,7 +321,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToXYPlane) {
   const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
   const UnitVec3 ray_direction(1.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -343,7 +343,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToXZPlane) {
   const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
   const UnitVec3 ray_direction(1.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -365,7 +365,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToYZPlane) {
   const BoundVec3 ray_origin(0.0, -15.0, -15.0);
   const UnitVec3 ray_direction(0.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -387,7 +387,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXPositiveYZ) {
   const BoundVec3 ray_origin(13.0, -15.0, -15.0);
   const UnitVec3 ray_direction(-1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
@@ -409,7 +409,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeYPositiveXZ) {
   const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
   const UnitVec3 ray_direction(1.0, -1.2, 1.3);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4,
                                                    4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 0, 0, 3, 3, 3};
@@ -432,7 +432,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeZPositiveXY) {
   const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
   const UnitVec3 ray_direction(1.4, 2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -454,7 +454,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXYZ) {
   const BoundVec3 ray_origin(15.0, 12.0, 15.0);
   const UnitVec3 ray_direction(-1.4, -2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 1, 1};
   const std::vector<int> expected_theta_voxels = {0, 3, 3, 3, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 1};
@@ -476,7 +476,7 @@ TEST(SphericalCoordinateTraversal, OddNumberAngularSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.3);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 1, 1, 0, 0};
@@ -498,7 +498,7 @@ TEST(SphericalCoordinateTraversal, OddNumberAzimuthalSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -520,7 +520,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {
       1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -555,7 +555,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAngularSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -577,7 +577,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
@@ -600,7 +600,7 @@ TEST(SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
   const UnitVec3 ray_direction(1.3, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/0.4);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.4);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};
@@ -622,7 +622,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsAtSphereOrigin) {
   const BoundVec3 ray_origin(0.0, 0.0, 0.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
@@ -644,7 +644,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginOne) {
   const BoundVec3 ray_origin(-3.0, 2.4, -3.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2};
@@ -666,7 +666,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginTwo) {
   const BoundVec3 ray_origin(-4.5, 3.6, -4.5);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2};
@@ -688,7 +688,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginThree) {
   const BoundVec3 ray_origin(-6.0, 4.8, -6.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1};
   const std::vector<int> expected_theta_voxels = {1};
   const std::vector<int> expected_phi_voxels = {2};
@@ -710,7 +710,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginFour) {
   const BoundVec3 ray_origin(-7.5, 6.0, -7.5);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {};
   const std::vector<int> expected_theta_voxels = {};
   const std::vector<int> expected_phi_voxels = {};
@@ -732,7 +732,7 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
   const BoundVec3 ray_origin(-5.0, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -754,7 +754,7 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelTwo) {
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 2, 2, 2};
@@ -777,7 +777,7 @@ TEST(SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0};
@@ -799,7 +799,7 @@ TEST(SphericalCoordinateTraversal, NearlyTangentialHit) {
   const BoundVec3 ray_origin(-5.01, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -820,7 +820,7 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
                                      sphere_center);
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(-11.0, 2.0, 1.0), UnitVec3(1.0, 0.0, 0.0)), grid,
-      /*t_end=*/1.0);
+      /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4,
                                                    4, 4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 2,
@@ -836,7 +836,7 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
   for (const auto &ray_origin : ray_origins) {
     const UnitVec3 ray_direction(0.0, 0.0, -1.0);
     const auto v = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
-                                       /*t_end=*/1.0);
+                                       /*max_t=*/1.0);
     EXPECT_NE(v.size(), 0);
   }
 }
@@ -855,7 +855,7 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereMiss) {
   const BoundVec3 ray_origin = BoundVec3(-5.0, -5.0, -5.0);
   const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const auto actual_voxels =
-      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
+      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, /*max_t=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -873,7 +873,7 @@ TEST(SphericalCoordinateTraversal, AvoidRaySteppingToRadialVoxelZero) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const Ray ray(BoundVec3(-984.375, 250.0, -10001.0), UnitVec3(0.0, 0.0, 1.0));
-  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/1.0);
   const std::size_t last_idx = actual_voxels.size() - 1;
   EXPECT_NE(actual_voxels[last_idx].radial, 0);
 }
@@ -903,7 +903,7 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
         const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
+            Ray(ray_origin, ray_direction), grid, /*max_t=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -925,7 +925,7 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
         const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
+            Ray(ray_origin, ray_direction), grid, /*max_t=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -946,7 +946,7 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
         const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
+            Ray(ray_origin, ray_direction), grid, /*max_t=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -973,7 +973,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
                                      sphere_center);
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(13.0, 13.0, 13.0), UnitVec3(-1.0, -1.0, -1.0)), grid,
-      /*t_end=*/1.0);
+      /*max_t=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
@@ -995,7 +995,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
                                      sphere_center);
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(13.0, -13.0, 13.0), UnitVec3(-1.0, 1.0, -1.0)), grid,
-      /*t_end=*/1.0);
+      /*max_t=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -60,12 +60,11 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(3.0, 3.0, 3.0);
-  const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
+  const UnitVec3 ray_direction(-2.0, -1.3, 1.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const double t_begin = 0.0;
-  const double t_end = 15.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -81,12 +80,11 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphereTangentialHit) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-10.0, -10.0, 0.0);
-  const FreeVec3 ray_direction(0.0, 1.0, 0.0);
+  const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const double t_begin = 0.0;
-  const double t_end = 15.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -102,11 +100,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
-  const FreeVec3 ray_direction(1.0, -1.0, -1.0);
+  const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3, 3, 3, 3, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0, 3, 3, 3, 3};
@@ -114,7 +112,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
+TEST(DISABLED_SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
@@ -126,11 +124,11 @@ TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(13.0, -15.0, 16.0);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 10.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
   const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
@@ -138,7 +136,7 @@ TEST(SphericalCoordinateTraversal, RayEndsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
+TEST(DISABLED_SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
@@ -150,11 +148,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
-  const FreeVec3 ray_direction(1.0, -1.0, -1.0);
+  const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 5.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -162,7 +160,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(SphericalCoordinateTraversal,
+TEST(DISABLED_SphericalCoordinateTraversal,
      RayBeginsAndEndsWithinSphereNotCenteredAtOrigin) {
   const BoundVec3 sphere_center(2.0, 3.0, 2.0);
   const double sphere_max_radius = 10.0;
@@ -175,11 +173,11 @@ TEST(SphericalCoordinateTraversal,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-1.0, 7.0, 7.0);
-  const FreeVec3 ray_direction(1.0, -1.0, -1.0);
+  const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 5.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -199,11 +197,11 @@ TEST(SphericalCoordinateTraversal, SphereCenteredAtOrigin) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -223,11 +221,11 @@ TEST(SphericalCoordinateTraversal, SphereNotCenteredAtOrigin) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-11.0, -11.0, -11.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -247,11 +245,11 @@ TEST(SphericalCoordinateTraversal, RaySlightOffsetInXYPlane) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
-  const FreeVec3 ray_direction(1.0, 1.5, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.5, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 2, 0, 0};
@@ -271,11 +269,11 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongXAxis) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
-  const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 3, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -295,11 +293,11 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongYAxis) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(0.0, -15.0, 0.0);
-  const FreeVec3 ray_direction(0.0, 1.0, 0.0);
+  const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {5, 5, 5, 5, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -319,11 +317,11 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongZAxis) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(0.0, 0.0, -15.0);
-  const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -343,11 +341,11 @@ TEST(SphericalCoordinateTraversal, RayParallelToXYPlane) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -367,11 +365,10 @@ TEST(SphericalCoordinateTraversal, RayParallelToXZPlane) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 0.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -391,11 +388,11 @@ TEST(SphericalCoordinateTraversal, RayParallelToYZPlane) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(0.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(0.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(0.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -415,11 +412,11 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXPositiveYZ) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(13.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(-1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(-1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
@@ -439,11 +436,11 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeYPositiveXZ) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
-  const FreeVec3 ray_direction(1.0, -1.2, 1.3);
+  const UnitVec3 ray_direction(1.0, -1.2, 1.3);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4,
                                                    4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 0, 0, 3, 3, 3};
@@ -464,11 +461,11 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeZPositiveXY) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
-  const FreeVec3 ray_direction(1.4, 2.0, -1.3);
+  const UnitVec3 ray_direction(1.4, 2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -488,11 +485,11 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXYZ) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(15.0, 12.0, 15.0);
-  const FreeVec3 ray_direction(-1.4, -2.0, -1.3);
+  const UnitVec3 ray_direction(-1.4, -2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 1, 1};
   const std::vector<int> expected_theta_voxels = {0, 3, 3, 3, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 1};
@@ -512,11 +509,11 @@ TEST(SphericalCoordinateTraversal, OddNumberAngularSections) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.3);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.3);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 1, 1, 0, 0};
@@ -536,11 +533,11 @@ TEST(SphericalCoordinateTraversal, OddNumberAzimuthalSections) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -560,11 +557,11 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSections) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {
       1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -597,11 +594,11 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAngularSections) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -621,11 +618,11 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
-  const FreeVec3 ray_direction(1.0, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
@@ -633,7 +630,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(SphericalCoordinateTraversal,
+TEST(DISABLED_SphericalCoordinateTraversal,
      RayBeginsInOutermostRadiusAndEndsWithinSphere) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
@@ -646,11 +643,11 @@ TEST(SphericalCoordinateTraversal,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
-  const FreeVec3 ray_direction(1.3, 1.0, 1.0);
+  const UnitVec3 ray_direction(1.3, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 4.3;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};
@@ -670,11 +667,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsAtSphereOrigin) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(0.0, 0.0, 0.0);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
@@ -694,11 +691,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginOne) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-3.0, 2.4, -3.0);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2};
@@ -718,11 +715,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginTwo) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-4.5, 3.6, -4.5);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2};
@@ -742,11 +739,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginThree) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-6.0, 4.8, -6.0);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1};
   const std::vector<int> expected_theta_voxels = {1};
   const std::vector<int> expected_phi_voxels = {2};
@@ -766,11 +763,11 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginFour) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-7.5, 6.0, -7.5);
-  const FreeVec3 ray_direction(-1.5, 1.2, -1.5);
+  const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {};
   const std::vector<int> expected_theta_voxels = {};
   const std::vector<int> expected_phi_voxels = {};
@@ -790,11 +787,11 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-5.0, 0.0, 10.0);
-  const FreeVec3 ray_direction(0.0, 0.0, -1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -814,11 +811,11 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelTwo) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
-  const FreeVec3 ray_direction(0.0, 0.0, -1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 2, 2, 2};
@@ -839,11 +836,11 @@ TEST(SphericalCoordinateTraversal,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
-  const FreeVec3 ray_direction(0.0, 0.0, -1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0};
@@ -863,11 +860,11 @@ TEST(SphericalCoordinateTraversal, NearlyTangentialHit) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const BoundVec3 ray_origin(-5.01, 0.0, 10.0);
-  const FreeVec3 ray_direction(0.0, 0.0, -1.0);
+  const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -886,11 +883,10 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = 35.0;
+
+  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
-      Ray(BoundVec3(-11.0, 2.0, 1.0), FreeVec3(1.0, 0.0, 0.0)), grid, t_begin,
-      t_end);
+      Ray(BoundVec3(-11.0, 2.0, 1.0), UnitVec3(1.0, 0.0, 0.0)), grid, t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4,
                                                    4, 4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 2,
@@ -905,9 +901,9 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
       BoundVec3(0.0, 0.0, 15.0), BoundVec3(-3.0, -3.0, 1.0),
       BoundVec3(-1.0, -5.0, 20.0)};
   for (const auto &ray_origin : ray_origins) {
-    const FreeVec3 ray_direction(0.0, 0.0, -1.0);
-    const auto v = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
-                                       t_begin, t_end);
+    const UnitVec3 ray_direction(0.0, 0.0, -1.0);
+    const auto v =
+        walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
     EXPECT_NE(v.size(), 0);
   }
 }
@@ -923,12 +919,12 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereMiss) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = 35.0;
+
+  const double t_end = 1.0;
   const BoundVec3 ray_origin = BoundVec3(-5.0, -5.0, -5.0);
-  const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const auto actual_voxels =
-      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -945,10 +941,10 @@ TEST(SphericalCoordinateTraversal, AvoidRaySteppingToRadialVoxelZero) {
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = sphere_max_radius * 3;
-  const Ray ray(BoundVec3(-984.375, 250.0, -10001.0), FreeVec3(0.0, 0.0, 1.0));
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_begin, t_end);
+
+  const double t_end = 1.0;
+  const Ray ray(BoundVec3(-984.375, 250.0, -10001.0), UnitVec3(0.0, 0.0, 1.0));
+  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
   const std::size_t last_idx = actual_voxels.size() - 1;
   EXPECT_NE(actual_voxels[last_idx].radial, 0);
 }
@@ -968,10 +964,10 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = sphere_max_radius * 3;
+
+  const double t_end = 1.0;
   {  // Z-axis
-    const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+    const UnitVec3 ray_direction(0.0, 0.0, 1.0);
     double ray_origin_x = -1000.0;
     double ray_origin_y = -1000.0;
     const double ray_origin_z = -(sphere_max_radius + 1.0);
@@ -980,8 +976,8 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+        const auto actual_voxels =
+            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -993,7 +989,7 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     }
   }
   {  // Y-axis
-    const FreeVec3 ray_direction(0.0, 1.0, 0.0);
+    const UnitVec3 ray_direction(0.0, 1.0, 0.0);
     double ray_origin_x = -1000.0;
     double ray_origin_z = -1000.0;
     const double ray_origin_y = -(sphere_max_radius + 1.0);
@@ -1002,8 +998,8 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+        const auto actual_voxels =
+            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -1015,7 +1011,7 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     }
   }
   {  // X-axis
-    const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+    const UnitVec3 ray_direction(1.0, 0.0, 0.0);
     double ray_origin_y = -1000.0;
     double ray_origin_z = -1000.0;
     const double ray_origin_x = -(sphere_max_radius + 1.0);
@@ -1024,8 +1020,8 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels = walkSphericalVolume(
-            Ray(ray_origin, ray_direction), grid, t_begin, t_end);
+        const auto actual_voxels =
+            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -1050,11 +1046,11 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
+
+  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
-      Ray(BoundVec3(13.0, 13.0, 13.0), FreeVec3(-1.0, -1.0, -1.0)), grid,
-      t_begin, t_end);
+      Ray(BoundVec3(13.0, 13.0, 13.0), UnitVec3(-1.0, -1.0, -1.0)), grid,
+      t_end);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
@@ -1074,11 +1070,11 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-  const double t_begin = 0.0;
-  const double t_end = 30.0;
+
+  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
-      Ray(BoundVec3(13.0, -13.0, 13.0), FreeVec3(-1.0, 1.0, -1.0)), grid,
-      t_begin, t_end);
+      Ray(BoundVec3(13.0, -13.0, 13.0), UnitVec3(-1.0, 1.0, -1.0)), grid,
+      t_end);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -62,9 +62,7 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphere) {
   const BoundVec3 ray_origin(3.0, 3.0, 3.0);
   const UnitVec3 ray_direction(-2.0, -1.3, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -82,9 +80,7 @@ TEST(SphericalCoordinateTraversal, RayDoesNotEnterSphereTangentialHit) {
   const BoundVec3 ray_origin(-10.0, -10.0, 0.0);
   const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -103,8 +99,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsWithinSphere) {
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3, 3, 3, 3, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0, 3, 3, 3, 3};
@@ -126,9 +121,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayEndsWithinSphere) {
   const BoundVec3 ray_origin(13.0, -15.0, 16.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3};
   const std::vector<int> expected_theta_voxels = {3, 3, 2, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 1, 1};
@@ -150,9 +143,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, RayBeginsAndEndsWithinSphere) {
   const BoundVec3 ray_origin(-3.0, 4.0, 5.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -175,9 +166,7 @@ TEST(DISABLED_SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-1.0, 7.0, 7.0);
   const UnitVec3 ray_direction(1.0, -1.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 3, 4, 4, 4};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 0, 3};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -199,9 +188,7 @@ TEST(SphericalCoordinateTraversal, SphereCenteredAtOrigin) {
   const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -223,9 +210,7 @@ TEST(SphericalCoordinateTraversal, SphereNotCenteredAtOrigin) {
   const BoundVec3 ray_origin(-11.0, -11.0, -11.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -248,8 +233,7 @@ TEST(SphericalCoordinateTraversal, RaySlightOffsetInXYPlane) {
   const UnitVec3 ray_direction(1.0, 1.5, 1.0);
   const Ray ray(ray_origin, ray_direction);
 
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 2, 0, 0};
@@ -271,9 +255,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongXAxis) {
   const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
   const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 3, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -295,9 +277,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongYAxis) {
   const BoundVec3 ray_origin(0.0, -15.0, 0.0);
   const UnitVec3 ray_direction(0.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {5, 5, 5, 5, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -319,9 +299,7 @@ TEST(SphericalCoordinateTraversal, RayTravelsAlongZAxis) {
   const BoundVec3 ray_origin(0.0, 0.0, -15.0);
   const UnitVec3 ray_direction(0.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -343,9 +321,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToXYPlane) {
   const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
   const UnitVec3 ray_direction(1.0, 1.0, 0.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -367,8 +343,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToXZPlane) {
   const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
   const UnitVec3 ray_direction(1.0, 0.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -390,9 +365,7 @@ TEST(SphericalCoordinateTraversal, RayParallelToYZPlane) {
   const BoundVec3 ray_origin(0.0, -15.0, -15.0);
   const UnitVec3 ray_direction(0.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -414,9 +387,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXPositiveYZ) {
   const BoundVec3 ray_origin(13.0, -15.0, -15.0);
   const UnitVec3 ray_direction(-1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {3, 3, 3, 2, 2, 1, 1, 1, 1};
@@ -438,9 +409,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeYPositiveXZ) {
   const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
   const UnitVec3 ray_direction(1.0, -1.2, 1.3);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4,
                                                    4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 0, 0, 3, 3, 3};
@@ -463,9 +432,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeZPositiveXY) {
   const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
   const UnitVec3 ray_direction(1.4, 2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
@@ -487,9 +454,7 @@ TEST(SphericalCoordinateTraversal, RayDirectionNegativeXYZ) {
   const BoundVec3 ray_origin(15.0, 12.0, 15.0);
   const UnitVec3 ray_direction(-1.4, -2.0, -1.3);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 1, 2, 1, 1};
   const std::vector<int> expected_theta_voxels = {0, 3, 3, 3, 2};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 1};
@@ -511,9 +476,7 @@ TEST(SphericalCoordinateTraversal, OddNumberAngularSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.3);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 1, 1, 0, 0};
@@ -535,9 +498,7 @@ TEST(SphericalCoordinateTraversal, OddNumberAzimuthalSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0, 0, 0, 0};
@@ -559,9 +520,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfRadialSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {
       1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -596,9 +555,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAngularSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
@@ -620,9 +577,7 @@ TEST(SphericalCoordinateTraversal, LargeNumberOfAzimuthalSections) {
   const BoundVec3 ray_origin(-15.0, -15.0, -15.0);
   const UnitVec3 ray_direction(1.0, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {24, 24, 24, 24, 4, 4, 4, 4};
@@ -645,9 +600,7 @@ TEST(DISABLED_SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-4.0, -4.0, -6.0);
   const UnitVec3 ray_direction(1.3, 1.0, 1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4};
   const std::vector<int> expected_theta_voxels = {2, 2, 2, 3, 3, 0};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 3, 3, 3};
@@ -669,9 +622,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsAtSphereOrigin) {
   const BoundVec3 ray_origin(0.0, 0.0, 0.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2, 2};
@@ -693,9 +644,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginOne) {
   const BoundVec3 ray_origin(-3.0, 2.4, -3.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2, 2};
@@ -717,9 +666,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginTwo) {
   const BoundVec3 ray_origin(-4.5, 3.6, -4.5);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1};
   const std::vector<int> expected_phi_voxels = {2, 2};
@@ -741,9 +688,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginThree) {
   const BoundVec3 ray_origin(-6.0, 4.8, -6.0);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1};
   const std::vector<int> expected_theta_voxels = {1};
   const std::vector<int> expected_phi_voxels = {2};
@@ -765,9 +710,7 @@ TEST(SphericalCoordinateTraversal, RayBeginsPastSphereOriginFour) {
   const BoundVec3 ray_origin(-7.5, 6.0, -7.5);
   const UnitVec3 ray_direction(-1.5, 1.2, -1.5);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {};
   const std::vector<int> expected_theta_voxels = {};
   const std::vector<int> expected_phi_voxels = {};
@@ -789,9 +732,7 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelOne) {
   const BoundVec3 ray_origin(-5.0, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -813,9 +754,7 @@ TEST(SphericalCoordinateTraversal, TangentialHitWithInnerRadialVoxelTwo) {
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 1, 2, 2, 2};
@@ -838,9 +777,7 @@ TEST(SphericalCoordinateTraversal,
   const BoundVec3 ray_origin(-2.5, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0, 0};
@@ -862,9 +799,7 @@ TEST(SphericalCoordinateTraversal, NearlyTangentialHit) {
   const BoundVec3 ray_origin(-5.01, 0.0, 10.0);
   const UnitVec3 ray_direction(0.0, 0.0, -1.0);
   const Ray ray(ray_origin, ray_direction);
-
-  const double t_end = 1.0;
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 2, 1};
   const std::vector<int> expected_theta_voxels = {1, 1, 1, 1};
   const std::vector<int> expected_phi_voxels = {1, 1, 2, 2};
@@ -883,10 +818,9 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
-      Ray(BoundVec3(-11.0, 2.0, 1.0), UnitVec3(1.0, 0.0, 0.0)), grid, t_end);
+      Ray(BoundVec3(-11.0, 2.0, 1.0), UnitVec3(1.0, 0.0, 0.0)), grid,
+      /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 3, 4, 4,
                                                    4, 4, 3, 3, 2, 1};
   const std::vector<int> expected_theta_voxels = {3, 3, 3, 2, 2, 2,
@@ -895,15 +829,14 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereHit) {
                                                 1, 0, 0, 0, 0, 0};
   verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                     expected_theta_voxels, expected_phi_voxels);
-
   const std::vector<BoundVec3> ray_origins = {
       BoundVec3(-5.0, -5.0, 5.0), BoundVec3(-1.0, -1.0, 10.0),
       BoundVec3(0.0, 0.0, 15.0), BoundVec3(-3.0, -3.0, 1.0),
       BoundVec3(-1.0, -5.0, 20.0)};
   for (const auto &ray_origin : ray_origins) {
     const UnitVec3 ray_direction(0.0, 0.0, -1.0);
-    const auto v =
-        walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
+    const auto v = walkSphericalVolume(Ray(ray_origin, ray_direction), grid,
+                                       /*t_end=*/1.0);
     EXPECT_NE(v.size(), 0);
   }
 }
@@ -919,12 +852,10 @@ TEST(SphericalCoordinateTraversal, UpperHemisphereMiss) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   const BoundVec3 ray_origin = BoundVec3(-5.0, -5.0, -5.0);
   const UnitVec3 ray_direction(1.0, 0.0, 0.0);
   const auto actual_voxels =
-      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
+      walkSphericalVolume(Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 
@@ -941,10 +872,8 @@ TEST(SphericalCoordinateTraversal, AvoidRaySteppingToRadialVoxelZero) {
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   const Ray ray(BoundVec3(-984.375, 250.0, -10001.0), UnitVec3(0.0, 0.0, 1.0));
-  const auto actual_voxels = walkSphericalVolume(ray, grid, t_end);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*t_end=*/1.0);
   const std::size_t last_idx = actual_voxels.size() - 1;
   EXPECT_NE(actual_voxels[last_idx].radial, 0);
 }
@@ -964,20 +893,17 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
   const svr::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   {  // Z-axis
     const UnitVec3 ray_direction(0.0, 0.0, 1.0);
     double ray_origin_x = -1000.0;
     double ray_origin_y = -1000.0;
     const double ray_origin_z = -(sphere_max_radius + 1.0);
-
     const double ray_origin_plane_movement = 2000.0 / 30;
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels =
-            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
+        const auto actual_voxels = walkSphericalVolume(
+            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -998,8 +924,8 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels =
-            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
+        const auto actual_voxels = walkSphericalVolume(
+            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -1015,13 +941,12 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
     double ray_origin_y = -1000.0;
     double ray_origin_z = -1000.0;
     const double ray_origin_x = -(sphere_max_radius + 1.0);
-
     const double ray_origin_plane_movement = 2000.0 / 30;
     for (std::size_t i = 0; i < 30; ++i) {
       for (std::size_t j = 0; j < 30; ++j) {
         const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, ray_origin_z);
-        const auto actual_voxels =
-            walkSphericalVolume(Ray(ray_origin, ray_direction), grid, t_end);
+        const auto actual_voxels = walkSphericalVolume(
+            Ray(ray_origin, ray_direction), grid, /*t_end=*/1.0);
         EXPECT_NE(actual_voxels.size(), 0);
         EXPECT_EQ(actual_voxels[0].radial, 1);
         const std::size_t last = actual_voxels.size() - 1;
@@ -1046,11 +971,9 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(13.0, 13.0, 13.0), UnitVec3(-1.0, -1.0, -1.0)), grid,
-      t_end);
+      /*t_end=*/1.0);
   const std::vector<int> expected_radial_voxels = {1, 2, 3, 4};
   const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
   const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
@@ -1070,11 +993,9 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
   const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
-
-  const double t_end = 1.0;
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(13.0, -13.0, 13.0), UnitVec3(-1.0, 1.0, -1.0)), grid,
-      t_end);
+      /*t_end=*/1.0);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -196,6 +196,116 @@ TEST(SphericalCoordinateTraversal, SphereCenteredAtOrigin) {
                     expected_theta_voxels, expected_phi_voxels);
 }
 
+TEST(SphericalCoordinateTraversal, RayOutsideSphereAndMaxTGreaterThanOne) {
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10.0;
+  const std::size_t num_radial_sections = 4;
+  const std::size_t num_polar_sections = 4;
+  const std::size_t num_azimuthal_sections = 4;
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
+  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+  const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
+  const Ray ray(ray_origin, ray_direction);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/10.0);
+  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
+  const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
+  const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
+  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
+                    expected_theta_voxels, expected_phi_voxels);
+}
+
+TEST(SphericalCoordinateTraversal, RayInsideSphereAndMaxTGreaterThanOne) {
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10.0;
+  const std::size_t num_radial_sections = 4;
+  const std::size_t num_polar_sections = 4;
+  const std::size_t num_azimuthal_sections = 4;
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
+  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
+  const Ray ray(ray_origin, ray_direction);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/10.0);
+  const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
+  const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
+  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
+  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
+                    expected_theta_voxels, expected_phi_voxels);
+}
+
+TEST(SphericalCoordinateTraversal, MaxTHalvedAndRayOutsideSphere) {
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10.0;
+  const std::size_t num_radial_sections = 4;
+  const std::size_t num_polar_sections = 4;
+  const std::size_t num_azimuthal_sections = 4;
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
+  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+  const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
+  const Ray ray(ray_origin, ray_direction);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.5);
+  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4};
+  const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0};
+  const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0};
+  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
+                    expected_theta_voxels, expected_phi_voxels);
+}
+
+TEST(SphericalCoordinateTraversal, MaxTHalvedAndRayInsideSphere) {
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10.0;
+  const std::size_t num_radial_sections = 4;
+  const std::size_t num_polar_sections = 4;
+  const std::size_t num_azimuthal_sections = 4;
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
+  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
+  const Ray ray(ray_origin, ray_direction);
+  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.5);
+  const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
+  const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
+  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
+  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
+                    expected_theta_voxels, expected_phi_voxels);
+}
+
+TEST(SphericalCoordinateTraversal, MaxTAtOrLessThanZero) {
+  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+  const double sphere_max_radius = 10.0;
+  const std::size_t num_radial_sections = 4;
+  const std::size_t num_polar_sections = 4;
+  const std::size_t num_azimuthal_sections = 4;
+  const svr::SphereBound max_bound = {
+      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
+  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
+                                     num_polar_sections, num_azimuthal_sections,
+                                     sphere_center);
+  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
+  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
+  const Ray ray(ray_origin, ray_direction);
+  const auto v1 = walkSphericalVolume(ray, grid, /*max_t=*/0.0);
+  const auto v2 = walkSphericalVolume(ray, grid, /*max_t=*/-0.1);
+  EXPECT_EQ(0, v1.size());
+  EXPECT_EQ(0, v2.size());
+}
+
+
+
 TEST(SphericalCoordinateTraversal, SphereNotCenteredAtOrigin) {
   const BoundVec3 sphere_center(2.0, 2.0, 2.0);
   const double sphere_max_radius = 10.0;

--- a/cpp/tests/test_svr.cpp
+++ b/cpp/tests/test_svr.cpp
@@ -304,8 +304,6 @@ TEST(SphericalCoordinateTraversal, MaxTAtOrLessThanZero) {
   EXPECT_EQ(0, v2.size());
 }
 
-
-
 TEST(SphericalCoordinateTraversal, SphereNotCenteredAtOrigin) {
   const BoundVec3 sphere_center(2.0, 2.0, 2.0);
   const double sphere_max_radius = 10.0;
@@ -1069,12 +1067,12 @@ TEST(SphericalCoordinateTraversal, VerifyManyRaysEntranceAndExit) {
   }
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
+TEST(SphericalCoordinateTraversal, FirstQuadrantHit) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
   const std::size_t num_polar_sections = 4;
-  const std::size_t num_azimuthal_sections = 8;
+  const std::size_t num_azimuthal_sections = 4;
   const svr::SphereBound max_bound = {.radial = sphere_max_radius,
                                       .polar = M_PI / 2.0,
                                       .azimuthal = M_PI / 2.0};
@@ -1082,16 +1080,16 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantHit) {
                                      num_polar_sections, num_azimuthal_sections,
                                      sphere_center);
   const auto actual_voxels = walkSphericalVolume(
-      Ray(BoundVec3(13.0, 13.0, 13.0), UnitVec3(-1.0, -1.0, -1.0)), grid,
-      /*max_t=*/1.0);
-  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4};
-  const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
-  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
+      Ray(BoundVec3(15.0, 15.0, 15.0), UnitVec3(-1.0, -1.0, -1.0)), grid,
+      /*max_t=*/0.5);
+  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4};
+  const std::vector<int> expected_theta_voxels = {1, 1, 1, 1, 0};
+  const std::vector<int> expected_phi_voxels = {1, 1, 1, 1, 0};
   verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                     expected_theta_voxels, expected_phi_voxels);
 }
 
-TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
+TEST(SphericalCoordinateTraversal, FirstQuadrantMiss) {
   const BoundVec3 sphere_center(0.0, 0.0, 0.0);
   const double sphere_max_radius = 10.0;
   const std::size_t num_radial_sections = 4;
@@ -1105,7 +1103,7 @@ TEST(DISABLED_SphericalCoordinateTraversal, FirstQuadrantMiss) {
                                      sphere_center);
   const auto actual_voxels = walkSphericalVolume(
       Ray(BoundVec3(13.0, -13.0, 13.0), UnitVec3(-1.0, 1.0, -1.0)), grid,
-      /*max_t=*/1.0);
+      /*max_t=*/0.5);
   EXPECT_EQ(actual_voxels.size(), 0);
 }
 


### PR DESCRIPTION
## Description

The yt version of walk_volume does not have a t_begin, and unitizes time and the ray direction. Our functionality should be similar. Doing so will require some refactoring.
### Changes
- Change ```t_end``` to ```max_t```.
- Set cythonized version ```max_t``` default value to 1.0
- Remove t_begin. This is not used in yt's ```walk_volume```, and its removal allows for the removal of unnecessary calculations. If one wants the ray to start at a different t_begin, the origin can be changed.
- Unitize the ray direction.
- Unitize the ray time. This is done by using ```max_t```. The documentation changes in the following way:
```
// max_t is the unitized time for which the ray may travel. It is used in the following
// linear function: ray_travel_duration = time_to_entrance + sphere.diameter() * max_t
// If the ray origin is within the sphere, then time_to_entrance is 0. Its
// expected values are within bounds [0.0, 1.0]. For example, if max_t <= 0.0,
// then no voxels will be traversed. If max_t >= 1.0, then the entire sphere
// will be traversed.
```
- Added CI tests with the ray placed randomly inside the sphere. Conducts similar basic property checks, except for those that require the ray to traverse the entire sphere.
- Removed RadialHitMetadata. It is simpler and easier to read to just provide a boolean value named ```is_radial_hit_transition```. This is then passed by reference into radialHit().
- Reduced number of calls to svr::isEqual() in minimumIntersection(). Now, this is only called a maximum of 3 times rather than (worst case) 8 times. I also save previous floating point comparison in variables to avoid calling the same comparison twice.
- Reduce number of calls to svr::isEqual() in angularHit(). Since svr::lessThan() checks to see if !svr::isEqual(), it is better to just save the value of svr::isEqual() in a variable and re-use it later.
- Remove ```.within_bounds``` from HitParameter. We can simply exit early if none of the values are within bounds.
- Add a constexpr value ```DOUBLE_MAX``` which represents the maximum value a double can be. This is the value tMax will be set to if no intersection occurs.

### Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

### How Has This Been Tested?
Below are a list of tests for a different ```max_t``` values. We can also get simple First Quadrant tests passing simply by setting ```max_t = 0.5```. This does **not** mean that sectored sphere traversal works, just a use case of the changes in this PR. All tests listed below are also added for the cythonized code.

```
TEST(SphericalCoordinateTraversal, RayOutsideSphereAndMaxTGreaterThanOne) {
  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
  const double sphere_max_radius = 10.0;
  const std::size_t num_radial_sections = 4;
  const std::size_t num_polar_sections = 4;
  const std::size_t num_azimuthal_sections = 4;
  const svr::SphereBound max_bound = {
      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                     num_polar_sections, num_azimuthal_sections,
                                     sphere_center);
  const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
  const Ray ray(ray_origin, ray_direction);
  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/10.0);
  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4, 3, 2, 1};
  const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
  const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0, 0, 0, 0};
  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                    expected_theta_voxels, expected_phi_voxels);
}

TEST(SphericalCoordinateTraversal, RayInsideSphereAndMaxTGreaterThanOne) {
  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
  const double sphere_max_radius = 10.0;
  const std::size_t num_radial_sections = 4;
  const std::size_t num_polar_sections = 4;
  const std::size_t num_azimuthal_sections = 4;
  const svr::SphereBound max_bound = {
      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                     num_polar_sections, num_azimuthal_sections,
                                     sphere_center);
  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
  const Ray ray(ray_origin, ray_direction);
  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/10.0);
  const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
  const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                    expected_theta_voxels, expected_phi_voxels);
}

TEST(SphericalCoordinateTraversal, MaxTHalvedAndRayOutsideSphere) {
  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
  const double sphere_max_radius = 10.0;
  const std::size_t num_radial_sections = 4;
  const std::size_t num_polar_sections = 4;
  const std::size_t num_azimuthal_sections = 4;
  const svr::SphereBound max_bound = {
      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                     num_polar_sections, num_azimuthal_sections,
                                     sphere_center);
  const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
  const Ray ray(ray_origin, ray_direction);
  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.5);
  const std::vector<int> expected_radial_voxels = {1, 2, 3, 4, 4};
  const std::vector<int> expected_theta_voxels = {2, 2, 2, 2, 0};
  const std::vector<int> expected_phi_voxels = {2, 2, 2, 2, 0};
  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                    expected_theta_voxels, expected_phi_voxels);
}

TEST(SphericalCoordinateTraversal, MaxTHalvedAndRayInsideSphere) {
  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
  const double sphere_max_radius = 10.0;
  const std::size_t num_radial_sections = 4;
  const std::size_t num_polar_sections = 4;
  const std::size_t num_azimuthal_sections = 4;
  const svr::SphereBound max_bound = {
      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                     num_polar_sections, num_azimuthal_sections,
                                     sphere_center);
  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
  const Ray ray(ray_origin, ray_direction);
  const auto actual_voxels = walkSphericalVolume(ray, grid, /*max_t=*/0.5);
  const std::vector<int> expected_radial_voxels = {4, 3, 2, 1};
  const std::vector<int> expected_theta_voxels = {0, 0, 0, 0};
  const std::vector<int> expected_phi_voxels = {0, 0, 0, 0};
  verifyEqualVoxels(actual_voxels, expected_radial_voxels,
                    expected_theta_voxels, expected_phi_voxels);
}

TEST(SphericalCoordinateTraversal, MaxTAtOrLessThanZero) {
  const BoundVec3 sphere_center(0.0, 0.0, 0.0);
  const double sphere_max_radius = 10.0;
  const std::size_t num_radial_sections = 4;
  const std::size_t num_polar_sections = 4;
  const std::size_t num_azimuthal_sections = 4;
  const svr::SphereBound max_bound = {
      .radial = sphere_max_radius, .polar = TAU, .azimuthal = TAU};
  const svr::SphericalVoxelGrid grid(MIN_BOUND, max_bound, num_radial_sections,
                                     num_polar_sections, num_azimuthal_sections,
                                     sphere_center);
  const BoundVec3 ray_origin(0.0, 0.0, 0.0);
  const UnitVec3 ray_direction(1.0, 1.0, 1.0);
  const Ray ray(ray_origin, ray_direction);
  const auto v1 = walkSphericalVolume(ray, grid, /*max_t=*/0.0);
  const auto v2 = walkSphericalVolume(ray, grid, /*max_t=*/-0.1);
  EXPECT_EQ(0, v1.size());
  EXPECT_EQ(0, v2.size());
}
```

### Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
