### PR TITLE
attempt to add enter_t exit_t to Voxels and fix some bounds logic

### DIFF
--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -512,6 +512,7 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
     if (current_radial_voxel + radial.tStep == 0 ||
         (radial.tMax == DOUBLE_MAX && polar.tMax == DOUBLE_MAX &&
          azimuthal.tMax == DOUBLE_MAX)) {
+        voxels.back().exit_t = t_ray_exit;
       return voxels;
     }
     const auto voxel_intersection =
@@ -571,9 +572,11 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
         voxels.back().azimuthal == current_azimuthal_voxel) {
       continue;
     }
+    voxels.back().exit_t = t;
     voxels.push_back({.radial = current_radial_voxel,
                       .polar = current_polar_voxel,
-                      .azimuthal = current_azimuthal_voxel});
+                      .azimuthal = current_azimuthal_voxel,
+                      .enter_t = t});
   }
 }
 

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -14,6 +14,8 @@ struct SphericalVoxel {
   int radial;
   int polar;
   int azimuthal;
+  double enter_t;
+  double exit_t;
 };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -95,7 +95,7 @@ struct SphericalVoxelGrid {
       }
       return;
     }
-    double radians = 0.0;
+    double radians = min_bound.polar;
     polar_trig_values_.resize(num_polar_sections + 1);
     std::generate(polar_trig_values_.begin(), polar_trig_values_.end(),
                   [&]() -> TrigonometricValues {
@@ -104,7 +104,7 @@ struct SphericalVoxelGrid {
                     radians += delta_theta_;
                     return {.cosine = cos, .sine = sin};
                   });
-    radians = 0.0;
+    radians = min_bound.azimuthal;
     azimuthal_trig_values_.resize(num_azimuthal_sections + 1);
     std::generate(azimuthal_trig_values_.begin(), azimuthal_trig_values_.end(),
                   [&]() -> TrigonometricValues {


### PR DESCRIPTION
I'm attempting to get the traversal working for the case that N_polar != N_azimuth, which seems to have some catches in it when doing volume rendering in yt.
